### PR TITLE
Publish prereleases only to GHPR, full also to NuGet.org

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,10 +64,10 @@ jobs:
           name: packages
           path: "**/*.nupkg"
 
-  publish:
-    name: Publish
+  publish-prerelease:
+    name: Publish prerelease
     runs-on: ubuntu-22.04
-    if: ${{ github.event_name == 'release' }}
+    if: ${{ github.event_name == 'release' && github.event.release.prerelease }}
     needs:
       - version
       - pack
@@ -75,6 +75,32 @@ jobs:
       matrix:
         environment:
           - ghpr
+
+    steps:
+      - name: Dispatch publishing
+        env:
+          GITHUB_TOKEN: ${{ secrets.PUBLISH_GITHUB_TOKEN }}
+        run: >
+          gh workflow run publish-nuget.yml
+          --repo bitwarden/devops
+          --field repository=${{ github.event.repository.name }}
+          --field run-id=${{ github.run_id }}
+          --field artifact=packages
+          --field environment=${{ matrix.environment }}
+          --field version=${{ needs.version.outputs.version }}
+
+  publish-release:
+    name: Publish release
+    runs-on: ubuntu-22.04
+    if: ${{ github.event_name == 'release' && !github.event.release.prerelease }}
+    needs:
+      - version
+      - pack
+    strategy:
+      matrix:
+        environment:
+          - ghpr
+          - nuget
 
     steps:
       - name: Dispatch publishing


### PR DESCRIPTION
## 🎟️ Tracking

Internal change, after discussion.

## 📔 Objective

To make adoption by most users easier, also publish full releases to NuGet.org. Allow pre-releases to just go to GitHub Packages.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
