### PR TITLE
Ignore tag research outcome

### DIFF
--- a/.github/workflows/pack-and-release.yml
+++ b/.github/workflows/pack-and-release.yml
@@ -109,7 +109,7 @@ jobs:
             const package = '${{ needs.parse.outputs.package }}';
             const currentVersion = '${{ needs.pack.outputs.current-version }}';
 
-            const currentRef = '${{ github.ref }}';
+            const currentRef = '${{ github.sha }}';
 
             // Configure Git
             await exec.exec(`git config user.name "github-actions"`);

--- a/.github/workflows/pack-and-release.yml
+++ b/.github/workflows/pack-and-release.yml
@@ -117,7 +117,7 @@ jobs:
 
             // List existing tags so that we could use them to link to the best full changelog
             // Debug purposes only right now until there is enough data for me to make this command bullet proof
-            await exec.exec(`git --no-pager tag --list "${package}_v*" --no-contains ${currentRef}`, [], {
+            await exec.exec(`git --no-pager tag --list "${package}_v*" --no-contains "${currentRef}"`, [], {
               listeners: {
                 stdout: function stdout(data) {
                   console.log(`Found tags:\n${data}`);

--- a/.github/workflows/pack-and-release.yml
+++ b/.github/workflows/pack-and-release.yml
@@ -109,18 +109,21 @@ jobs:
             const package = '${{ needs.parse.outputs.package }}';
             const currentVersion = '${{ needs.pack.outputs.current-version }}';
 
+            const currentRef = '${{ github.ref }}';
+
             // Configure Git
             await exec.exec(`git config user.name "github-actions"`);
             await exec.exec(`git config user.email "github-actions@github.com"`);
 
             // List existing tags so that we could use them to link to the best full changelog
             // Debug purposes only right now until there is enough data for me to make this command bullet proof
-            await exec.exec(`git --no-pager tag --list "${package}_v*" --no-contains $(git rev-parse HEAD)`, [], {
+            await exec.exec(`git --no-pager tag --list "${package}_v*" --no-contains ${currentRef}`, [], {
               listeners: {
                 stdout: function stdout(data) {
                   console.log(`Found tags:\n${data}`);
                 }
-              }
+              },
+              ignoreErrorCode: true // Just for research purposes right now, it's fine if this fails
             });
 
             // Create tag


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Fixes round 4

The `git --no-pager tag --list "${package}_v*" --no-contains ${currentRef}` is just a little research on my part to see if this could be used to get the most recent tag just for the tag and release we are creating so that we can generate release notes. Right now the auto release notes uses the last tag automatically but that won't be right if we are releasing multiple packages. This command will hopefully get us there but it is currently failing because what I assume is a command within a command not being allowed.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
