### PR TITLE
Innovation opaque seeded generation

### DIFF
--- a/extensions/Bitwarden.Opaque/rust/Cargo.lock
+++ b/extensions/Bitwarden.Opaque/rust/Cargo.lock
@@ -234,6 +234,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hkdf"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -321,8 +327,10 @@ dependencies = [
  "argon2",
  "digest",
  "generic-array",
+ "hex",
  "opaque-ke",
  "rand",
+ "rand_chacha",
  "serde",
  "serde_json",
  "voprf",

--- a/extensions/Bitwarden.Opaque/rust/Cargo.toml
+++ b/extensions/Bitwarden.Opaque/rust/Cargo.toml
@@ -11,8 +11,10 @@ crate-type = ["cdylib"]
 argon2 = "0.5.3"
 digest = "0.10.7"
 generic-array = "0.14.7"
+hex = "0.4.3"
 opaque-ke = { version = "3.0.0", features = ["std", "argon2", "curve25519"] }
 rand = "0.8.5"
+rand_chacha = "0.3.1"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 voprf = "0.5.0"

--- a/extensions/Bitwarden.Opaque/rust/src/ffi/mod.rs
+++ b/extensions/Bitwarden.Opaque/rust/src/ffi/mod.rs
@@ -8,10 +8,38 @@ use crate::{
 
 mod types;
 
+use rand::RngCore;
 use types::*;
+
+#[cfg(test)]
+pub use types::Buffer;
 
 unsafe fn parse_str<'a>(input: *const c_char, name: &'static str) -> Result<&'a str, Error> {
     unsafe { std::ffi::CStr::from_ptr(input).to_str() }.map_err(|_| Error::InvalidInput(name.into()))
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn register_seeded_fake_config(seed: Buffer) -> Response {
+    let seed = try_ffi!(unsafe { seed.as_slice() });
+    if seed.len() != 32 {
+       try_ffi!(Err(Error::InvalidInput("Seed must be 32 bytes".into()))); 
+    }
+    let seed = try_ffi!(<[u8; 32]>::try_from(seed).map_err(|_| Error::InvalidInput("Seed must be 32 bytes".into())));
+    let config = CipherConfiguration::fake_from_seed(seed);
+
+    let rng = try_ffi!(config.rng.as_ref().ok_or(Error::InvalidInput("No rng found".into())));
+    let mut password: [u8; 32] = [0; 32];
+    rng.borrow_mut().fill_bytes(&mut password);
+    let password = hex::encode(password);
+    let mut username: [u8; 32] = [0; 32];
+    rng.borrow_mut().fill_bytes(&mut username);
+    let username = hex::encode(username);
+
+    let start = try_ffi!(config.start_client_registration(&password.as_str()));
+    let server_start = try_ffi!(config.start_server_registration(None, &start.registration_request, &username));
+    let client_finish = try_ffi!(config.finish_client_registration(&start.state, &server_start.registration_response, &password));
+    let server_finish = try_ffi!(config.finish_server_registration(&client_finish.registration_upload));
+    Response::ok2(server_start.server_setup, server_finish.server_registration)
 }
 
 ///

--- a/extensions/Bitwarden.Opaque/rust/src/lib.rs
+++ b/extensions/Bitwarden.Opaque/rust/src/lib.rs
@@ -23,7 +23,7 @@ impl From<opaque_ke::errors::ProtocolError> for Error {
 
 #[cfg(test)]
 mod tests {
-    use crate::{ffi::{self, register_seeded_fake_config}, opaque::*};
+    use crate::opaque::*;
 
     #[test]
     fn test() {
@@ -86,10 +86,8 @@ mod tests {
     #[test]
     fn test_seeded() {
         let seed = [0u8; 32];
-        let buffer = ffi::Buffer::from_vec(seed.to_vec());
-        let res = unsafe { register_seeded_fake_config(buffer) };
-        assert!(res.error == 0);
-        let (server_setup, password_file) = unsafe { (res.data1.as_slice().unwrap(), res.data2.as_slice().unwrap()) };
+        let (server_setup, password_file) =
+            super::opaque::register_seeded_fake_config(seed).unwrap();
         assert_eq!(server_setup.len(), 128);
         assert_eq!(password_file.len(), 192);
 
@@ -99,8 +97,8 @@ mod tests {
         let res = config.start_client_login(password).unwrap();
         let server_res = config
             .start_server_login(
-                server_setup,
-                password_file,
+                &server_setup,
+                &password_file,
                 &res.credential_request,
                 username,
             )

--- a/extensions/Bitwarden.Opaque/rust/src/lib.rs
+++ b/extensions/Bitwarden.Opaque/rust/src/lib.rs
@@ -23,7 +23,7 @@ impl From<opaque_ke::errors::ProtocolError> for Error {
 
 #[cfg(test)]
 mod tests {
-    use crate::opaque::*;
+    use crate::{ffi::{self, register_seeded_fake_config}, opaque::*};
 
     #[test]
     fn test() {
@@ -81,5 +81,31 @@ mod tests {
             .unwrap();
 
         let _ = server_login_finish_result.session_key;
+    }
+
+    #[test]
+    fn test_seeded() {
+        let seed = [0u8; 32];
+        let buffer = ffi::Buffer::from_vec(seed.to_vec());
+        let res = unsafe { register_seeded_fake_config(buffer) };
+        assert!(res.error == 0);
+        let (server_setup, password_file) = unsafe { (res.data1.as_slice().unwrap(), res.data2.as_slice().unwrap()) };
+        assert_eq!(server_setup.len(), 128);
+        assert_eq!(password_file.len(), 192);
+
+        let password = "password";
+        let username = "username";
+        let config = CipherConfiguration::default();
+        let res = config.start_client_login(password).unwrap();
+        let server_res = config
+            .start_server_login(
+                server_setup,
+                password_file,
+                &res.credential_request,
+                username,
+            )
+            .unwrap();
+        let res = config.finish_client_login(&res.state, &server_res.credential_response, password);
+        assert!(res.is_err());
     }
 }

--- a/extensions/Bitwarden.Opaque/rust/src/opaque/mod.rs
+++ b/extensions/Bitwarden.Opaque/rust/src/opaque/mod.rs
@@ -1,7 +1,6 @@
 use std::cell::RefCell;
 
 use opaque_ke::*;
-use rand::rngs::OsRng;
 use rand_chacha::{rand_core::SeedableRng, ChaCha20Rng};
 
 use crate::Error;
@@ -201,7 +200,7 @@ impl OpaqueImpl for RistrettoTripleDhArgonSuite {
         &self,
         password: &str,
     ) -> Result<types::ClientRegistrationStartResult, Error> {
-        let result = ClientRegistration::<Self>::start(&mut OsRng, password.as_bytes())?;
+        let result = ClientRegistration::<Self>::start(self.get_rng().get_mut(), password.as_bytes())?;
         Ok(types::ClientRegistrationStartResult {
             registration_request: result.message.serialize().to_vec(),
             state: result.state.serialize().to_vec(),
@@ -260,7 +259,7 @@ impl OpaqueImpl for RistrettoTripleDhArgonSuite {
     }
 
     fn start_client_login(&self, password: &str) -> Result<types::ClientLoginStartResult, Error> {
-        let result = ClientLogin::<Self>::start(&mut OsRng, password.as_bytes())?;
+        let result = ClientLogin::<Self>::start(self.get_rng().get_mut(), password.as_bytes())?;
         Ok(types::ClientLoginStartResult {
             credential_request: result.message.serialize().to_vec(),
             state: result.state.serialize().to_vec(),
@@ -274,7 +273,7 @@ impl OpaqueImpl for RistrettoTripleDhArgonSuite {
         username: &str,
     ) -> Result<types::ServerLoginStartResult, Error> {
         let result = ServerLogin::start(
-            &mut OsRng,
+            self.get_rng().get_mut(),
             &ServerSetup::<Self>::deserialize(server_setup)?,
             Some(ServerRegistration::<Self>::deserialize(
                 server_registration,

--- a/extensions/Bitwarden.Opaque/rust/src/opaque/types.rs
+++ b/extensions/Bitwarden.Opaque/rust/src/opaque/types.rs
@@ -52,14 +52,18 @@ pub struct CipherConfiguration {
     pub key_exchange: KeyExchange,
     pub ksf: Ksf,
 
-    #[serde(skip)]
-    pub(crate) rng: Option<RefCell<ChaCha20Rng>>,
+    #[serde(skip, default = "default_rng")]
+    pub(crate) rng: RefCell<ChaCha20Rng>,
+}
+
+fn default_rng() -> RefCell<ChaCha20Rng> {
+    RefCell::from(ChaCha20Rng::from_entropy())
 }
 
 impl CipherConfiguration {
     pub(crate) fn fake_from_seed(seed: [u8; 32]) -> Self {
         Self {
-            rng: Some(RefCell::from(ChaCha20Rng::from_seed(seed))),
+            rng: RefCell::from(ChaCha20Rng::from_seed(seed)),
             ..Default::default()
         }
     }
@@ -77,7 +81,7 @@ impl Default for CipherConfiguration {
                 iterations: 4,
                 parallelism: 4,
             }),
-            rng: Some(RefCell::from(ChaCha20Rng::from_entropy())),
+            rng: default_rng(),
         }
     }
 }
@@ -137,8 +141,7 @@ pub(crate) struct ServerLoginFinishResult {
 }
 
 #[derive(Debug, Default)]
-pub(crate) struct IdentityKsf {
-}
+pub(crate) struct IdentityKsf {}
 
 impl opaque_ke::ksf::Ksf for IdentityKsf {
     fn hash<L: ArrayLength<u8>>(
@@ -146,5 +149,5 @@ impl opaque_ke::ksf::Ksf for IdentityKsf {
         input: GenericArray<u8, L>,
     ) -> Result<GenericArray<u8, L>, InternalError> {
         Ok(input)
-    } 
+    }
 }

--- a/extensions/Bitwarden.Opaque/src/BitwardenLibrary.cs
+++ b/extensions/Bitwarden.Opaque/src/BitwardenLibrary.cs
@@ -41,6 +41,9 @@ internal static partial class BitwardenLibrary
     private static partial void free_buffer(Buffer buf);
 
     [LibraryImport("opaque_ke_binding", StringMarshalling = StringMarshalling.Utf8)]
+    private static partial Response register_seeded_fake_config(Buffer seed);
+
+    [LibraryImport("opaque_ke_binding", StringMarshalling = StringMarshalling.Utf8)]
     private static partial Response start_client_registration(string config, string password);
 
     [LibraryImport("opaque_ke_binding", StringMarshalling = StringMarshalling.Utf8)]
@@ -120,6 +123,15 @@ internal static partial class BitwardenLibrary
         Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) }, // Converts enums to strings
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase
     };
+
+    internal static (byte[], byte[]) RegisterSeededFakeConfig(byte[] seed)
+    {
+        var response = register_seeded_fake_config(BuildBuffer(seed, out var handle));
+        try {
+            var responseValues = HandleResponse(response, 2);
+            return (responseValues[0], responseValues[1]); 
+        } finally { handle.Free(); }
+    }
 
     internal static (byte[], byte[]) StartClientRegistration(CipherConfiguration config, string password)
     {

--- a/extensions/Bitwarden.Opaque/src/BitwardenOpaqueServer.cs
+++ b/extensions/Bitwarden.Opaque/src/BitwardenOpaqueServer.cs
@@ -124,7 +124,7 @@ public sealed partial class BitwardenOpaqueServer
         var result = BitwardenLibrary.ExecuteFFIFunction((ffi) =>
         {
             return BitwardenLibrary.register_seeded_fake_config(ffi.Buf(seed));
-        }, 1);
+        }, 2);
         return (result[0], result[1]);
     }
 

--- a/extensions/Bitwarden.Opaque/src/BitwardenOpaqueServer.cs
+++ b/extensions/Bitwarden.Opaque/src/BitwardenOpaqueServer.cs
@@ -121,7 +121,11 @@ public sealed partial class BitwardenOpaqueServer
 
     public (byte[] serverSetup, byte[] serverRegistration) SeededFakeRegistration(byte[] seed)
     {
-        return BitwardenLibrary.RegisterSeededFakeConfig(seed);
+        var result = BitwardenLibrary.ExecuteFFIFunction((ffi) =>
+        {
+            return BitwardenLibrary.register_seeded_fake_config(ffi.Buf(seed));
+        }, 1);
+        return (result[0], result[1]);
     }
 
 }

--- a/extensions/Bitwarden.Opaque/src/BitwardenOpaqueServer.cs
+++ b/extensions/Bitwarden.Opaque/src/BitwardenOpaqueServer.cs
@@ -86,4 +86,9 @@ public sealed partial class BitwardenOpaqueServer
         };
     }
 
+    public (byte[] serverSetup, byte[] serverRegistration) SeededFakeRegistration(byte[] seed)
+    {
+        return BitwardenLibrary.RegisterSeededFakeConfig(seed);
+    }
+
 }

--- a/extensions/Bitwarden.Opaque/tests/Tests.cs
+++ b/extensions/Bitwarden.Opaque/tests/Tests.cs
@@ -5,6 +5,25 @@ using Xunit;
 public class SampleTests
 {
     [Fact]
+    public void TestSeededRegistration()
+    {
+        var server = new BitwardenOpaqueServer();
+
+        var seed = new byte[32];
+        var (serverSetup1, serverRegistration1) = server.SeededFakeRegistration(seed);
+
+        Assert.NotNull(serverSetup1);
+        Assert.NotNull(serverRegistration1);
+
+        var (serverSetup2, serverRegistration2) = server.SeededFakeRegistration(seed);
+        Assert.NotNull(serverSetup2);
+        Assert.NotNull(serverRegistration2);
+
+        Assert.Equal(serverSetup1, serverSetup2);
+        Assert.Equal(serverRegistration1, serverRegistration2);
+    }
+
+    [Fact]
     public void TestRegistration()
     {
         // Get environment variables


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
Adds seeded generation for opaque generations. For this, the RNG is replaced with a Chacha20Rng. By default it is seeded from the OsRng; it can alternatively be seeded by an input bytearray. This is then used to do a local registration to end up with a deterministic credential based on a secret seed.

The KSF run locally, is replaced with the identity function (no-op), 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
