### PR TITLE
Update Nuget to not pin dependencies

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,8 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>bitwarden/renovate-config"],
+  "extends": ["github>bitwarden/renovate-config/non-pinned.json"],
   "enabledManagers": ["github-actions", "nuget"],
   "packageRules": [
+    {
+      "matchManagers": ["github-actions"],
+      "rangeStrategy": "pin"
+    },
     {
       "groupName": "gh minor",
       "matchManagers": ["github-actions"],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,11 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>bitwarden/renovate-config/non-pinned.json"],
+  "extends": ["github>bitwarden/renovate-config"],
   "enabledManagers": ["github-actions", "nuget"],
   "packageRules": [
     {
-      "matchManagers": ["github-actions"],
-      "rangeStrategy": "pin"
+      "matchManagers": ["nuget"],
+      "rangeStrategy": "auto"
     },
     {
       "groupName": "gh minor",


### PR DESCRIPTION
## 📔 Objective

Since Renovate is now pinning Nuget dependencies, we want to avoid doing so for libraries (to avoid requiring clients to have specific versions).

To accomplish this, we'll override the default configuration, which pins all dependencies, and tell Renovate _not_ to pin Nuget.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
