### PR TITLE
[PM-18069] Add context builder for features

### DIFF
--- a/extensions/Bitwarden.Server.Sdk.Features/src/AnonymousContextBuilder.cs
+++ b/extensions/Bitwarden.Server.Sdk.Features/src/AnonymousContextBuilder.cs
@@ -1,0 +1,14 @@
+using LaunchDarkly.Sdk;
+
+namespace Bitwarden.Server.Sdk.Features;
+
+internal sealed class AnonymousContextBuilder : IContextBuilder
+{
+    private const string AnonymousUser = "25a15cac-58cf-4ac0-ad0f-b17c4bd92294";
+
+    public Context Build()
+    {
+        return Context.Builder(ContextKind.Default, AnonymousUser)
+            .Build();
+    }
+}

--- a/extensions/Bitwarden.Server.Sdk.Features/src/HostEnvironmentExtensions.cs
+++ b/extensions/Bitwarden.Server.Sdk.Features/src/HostEnvironmentExtensions.cs
@@ -1,4 +1,3 @@
-using System.ComponentModel;
 using System.Reflection;
 using Microsoft.Extensions.Hosting;
 

--- a/extensions/Bitwarden.Server.Sdk.Features/src/IContextBuilder.cs
+++ b/extensions/Bitwarden.Server.Sdk.Features/src/IContextBuilder.cs
@@ -1,0 +1,29 @@
+using LaunchDarkly.Sdk;
+
+namespace Bitwarden.Server.Sdk.Features;
+
+/// <summary>
+/// A service for customizing the building of <see cref="Context"/> for your application.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This service will be registered as a <see cref="Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton"/>.
+/// </para>
+/// <para>
+/// To customize specifically for an HTTP call it's recommended to use <see cref="Microsoft.AspNetCore.Http.IHttpContextAccessor"/>
+/// and access the <see cref="Microsoft.AspNetCore.Http.IHttpContextAccessor.HttpContext"/> property. If that value is
+/// not <see langword="null" /> then you can use <see cref="Microsoft.AspNetCore.Http.HttpContext.RequestServices"/> to
+/// obtain request scoped services that can be used to build your context. If that value is <see langword="null"/> then
+/// the feature flag check is not happening during the context of an HTTP call. It is likely that it's instead taking
+/// place in a <see cref="Microsoft.Extensions.Hosting.IHostedService"/>.
+/// </para>
+/// </remarks>
+public interface IContextBuilder
+{
+    /// <summary>
+    /// Called the first time a feature flag value is requested in each service scope. The returned value is cached
+    /// for all subsequent feature flag requests.
+    /// </summary>
+    /// <returns>The Context to use for all feature flag requests in this service scope.</returns>
+    public Context Build();
+}

--- a/extensions/Bitwarden.Server.Sdk.Features/tests/Bitwarden.Server.Sdk.Features.Tests/FeatureApplicationBuilderExtensionsTests.cs
+++ b/extensions/Bitwarden.Server.Sdk.Features/tests/Bitwarden.Server.Sdk.Features.Tests/FeatureApplicationBuilderExtensionsTests.cs
@@ -1,4 +1,3 @@
-using Bitwarden.Server.Sdk.Features;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;

--- a/extensions/Bitwarden.Server.Sdk.Features/tests/Bitwarden.Server.Sdk.Features.Tests/FeatureCheckMiddlewareTests.cs
+++ b/extensions/Bitwarden.Server.Sdk.Features/tests/Bitwarden.Server.Sdk.Features.Tests/FeatureCheckMiddlewareTests.cs
@@ -166,8 +166,7 @@ public class FeatureCheckMiddlewareTests
                     {
                         services.AddRouting();
 
-                        // We will manually add configuration later so this being empty is fine
-                        services.AddFeatureFlagServices(context.Configuration);
+                        services.AddFeatureFlagServices();
 
                         configureServices?.Invoke(services);
                     })

--- a/extensions/Bitwarden.Server.Sdk.Features/tests/Bitwarden.Server.Sdk.Features.Tests/FeatureServiceCollectionExtensionsTests.cs
+++ b/extensions/Bitwarden.Server.Sdk.Features/tests/Bitwarden.Server.Sdk.Features.Tests/FeatureServiceCollectionExtensionsTests.cs
@@ -1,11 +1,30 @@
 using Bitwarden.Server.Sdk.Features;
+using LaunchDarkly.Sdk;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 
 namespace Bitwarden.Server.Sdk.UnitTests.Features;
 
 public class FeatureServiceCollectionExtensionsTests
 {
+    [Fact]
+    public void AddFeatureFlagServices_Works()
+    {
+        var builder = Host.CreateEmptyApplicationBuilder(new HostApplicationBuilderSettings
+        {
+            ApplicationName = "Bitwarden.Server.Sdk.Features.Tests",
+        });
+
+        builder.Services.AddFeatureFlagServices();
+
+        var host = builder.Build();
+
+        _ = host.Services.GetRequiredService<IFeatureService>();
+    }
+
     [Fact]
     public void AddKnownFeatureFlags_Works()
     {
@@ -85,5 +104,28 @@ public class FeatureServiceCollectionExtensionsTests
 
         var featureThreeValue = Assert.Contains("feature-three", featureFlagOptions.FlagValues);
         Assert.Equal("1", featureThreeValue);
+    }
+
+    [Fact]
+    public void AddContextBuilder_Works()
+    {
+        var services = new ServiceCollection();
+        services.AddContextBuilder<TestContextBuilder>();
+        var sp = services.BuildServiceProvider();
+
+        var contextBuilder = sp.GetRequiredService<IContextBuilder>();
+
+        var context = contextBuilder.Build();
+
+        Assert.Equal("User", context.Kind.Value);
+        Assert.Equal("test-user", context.Key);
+    }
+
+    private class TestContextBuilder : IContextBuilder
+    {
+        public Context Build()
+        {
+            return Context.New(ContextKind.Of("User"), "test-user");
+        }
     }
 }

--- a/extensions/Bitwarden.Server.Sdk.Features/tests/Bitwarden.Server.Sdk.Features.Tests/LaunchDarklyFeatureServiceTests.cs
+++ b/extensions/Bitwarden.Server.Sdk.Features/tests/Bitwarden.Server.Sdk.Features.Tests/LaunchDarklyFeatureServiceTests.cs
@@ -2,7 +2,6 @@ using Bitwarden.Server.Sdk.Features;
 using LaunchDarkly.Sdk;
 using LaunchDarkly.Sdk.Server;
 using LaunchDarkly.Sdk.Server.Interfaces;
-using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using NSubstitute;
@@ -12,7 +11,7 @@ namespace Bitwarden.Server.Sdk.UnitTests.Features;
 public class LaunchDarklyFeatureServiceTests
 {
     private readonly ILdClient _ldClient;
-    private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly IContextBuilder _contextBuilder;
     private readonly IOptionsMonitor<FeatureFlagOptions> _featureFlagOptions;
 
     private readonly LaunchDarklyFeatureService _sut;
@@ -20,12 +19,12 @@ public class LaunchDarklyFeatureServiceTests
     public LaunchDarklyFeatureServiceTests()
     {
         _ldClient = Substitute.For<ILdClient>();
-        _httpContextAccessor = Substitute.For<IHttpContextAccessor>();
+        _contextBuilder = Substitute.For<IContextBuilder>();
         _featureFlagOptions = Substitute.For<IOptionsMonitor<FeatureFlagOptions>>();
 
         _sut = new LaunchDarklyFeatureService(
             _ldClient,
-            _httpContextAccessor,
+            _contextBuilder,
             _featureFlagOptions,
             NullLogger<LaunchDarklyFeatureService>.Instance
         );
@@ -104,9 +103,7 @@ public class LaunchDarklyFeatureServiceTests
         _ = _sut.IsEnabled("feature-one");
 
         // Use the access of the HttpContext as the indicator that it was only built from once
-        _httpContextAccessor
-            .HttpContext
-            .Received(1);
+        _contextBuilder.Received(1).Build();
     }
 
     [Theory]

--- a/extensions/Bitwarden.Server.Sdk/src/Bitwarden.Server.Sdk.csproj
+++ b/extensions/Bitwarden.Server.Sdk/src/Bitwarden.Server.Sdk.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.Build.NoTargets">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <PackageType>MSBuildSdk</PackageType>
@@ -49,20 +49,6 @@
 
   <ItemGroup>
     <Content Include="Content/**/*.cs" Pack="true" PackagePath="Content" Visible="false" BuildAction="none" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="[1.12.0]" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="[1.12.0]" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="[1.12.0]" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="[1.12.0]" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="[1.12.0]" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="[1.12.0-beta.2]" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="[1.12.0]" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\..\Bitwarden.Server.Sdk.Features\src\Bitwarden.Server.Sdk.Features.csproj" />
   </ItemGroup>
 
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,4 +1,7 @@
 {
+  "msbuild-sdks": {
+    "Microsoft.Build.NoTargets": "3.7.134"
+  },
   "sdk": {
     "version": "8.0.100",
     "rollForward": "latestFeature"


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

Part of https://bitwarden.atlassian.net/browse/PM-18069

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Introduce a integration point of `IContextBuilder` this can be implemented by consuming services to allow them to customize the context to their liking. `server` will implement this using `ICurrentContext`. If no service is added then all flags are evaluated with an pre-defined anonymous user.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
