### PR TITLE
[PM-12640] Add Bitwarden.Server.Sdk.Authentication Package

### DIFF
--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -11,6 +11,7 @@ on:
         options:
         - Bitwarden.Server.Sdk
         - Bitwarden.Server.Sdk.Features
+        - Bitwarden.Server.Sdk.Authentication
 
 permissions:
   pull-requests: write

--- a/bitwarden-dotnet.sln
+++ b/bitwarden-dotnet.sln
@@ -45,6 +45,14 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{4949B721
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bitwarden.Server.Sdk.Features.Tests", "extensions\Bitwarden.Server.Sdk.Features\tests\Bitwarden.Server.Sdk.Features.Tests\Bitwarden.Server.Sdk.Features.Tests.csproj", "{1789F567-87B3-4313-80CF-E3CCFA1B6D5E}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Bitwarden.Server.Sdk.Authentication", "Bitwarden.Server.Sdk.Authentication", "{79CC5F16-EEB8-4539-AA15-FDC1E9AB03D1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bitwarden.Server.Sdk.Authentication", "extensions\Bitwarden.Server.Sdk.Authentication\src\Bitwarden.Server.Sdk.Authentication.csproj", "{0E96965A-4397-46A8-8D84-330ACFF2F8CF}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{D623B9E7-6555-45AB-AAEC-EA388FACCE11}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bitwarden.Server.Sdk.Authentication.Tests", "extensions\Bitwarden.Server.Sdk.Authentication\tests\Bitwarden.Server.Sdk.Authentication.Tests\Bitwarden.Server.Sdk.Authentication.Tests.csproj", "{5AA835F4-F265-403F-897C-8989E354C052}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -102,6 +110,14 @@ Global
 		{1789F567-87B3-4313-80CF-E3CCFA1B6D5E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1789F567-87B3-4313-80CF-E3CCFA1B6D5E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1789F567-87B3-4313-80CF-E3CCFA1B6D5E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0E96965A-4397-46A8-8D84-330ACFF2F8CF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0E96965A-4397-46A8-8D84-330ACFF2F8CF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0E96965A-4397-46A8-8D84-330ACFF2F8CF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0E96965A-4397-46A8-8D84-330ACFF2F8CF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5AA835F4-F265-403F-897C-8989E354C052}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5AA835F4-F265-403F-897C-8989E354C052}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5AA835F4-F265-403F-897C-8989E354C052}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5AA835F4-F265-403F-897C-8989E354C052}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{5EC8B943-2E9E-437D-9FFC-D18B5DB4D7D0} = {695C76EF-1102-4805-970F-7C995EE54930}
@@ -124,5 +140,9 @@ Global
 		{DF914CD1-F916-4A58-B749-625DB67FAAA7} = {026589E0-5AAA-44EB-B973-3CFFF5B54AFC}
 		{4949B721-5C7F-4D85-AB35-F57B54D7A6E6} = {026589E0-5AAA-44EB-B973-3CFFF5B54AFC}
 		{1789F567-87B3-4313-80CF-E3CCFA1B6D5E} = {4949B721-5C7F-4D85-AB35-F57B54D7A6E6}
+		{79CC5F16-EEB8-4539-AA15-FDC1E9AB03D1} = {695C76EF-1102-4805-970F-7C995EE54930}
+		{0E96965A-4397-46A8-8D84-330ACFF2F8CF} = {79CC5F16-EEB8-4539-AA15-FDC1E9AB03D1}
+		{D623B9E7-6555-45AB-AAEC-EA388FACCE11} = {79CC5F16-EEB8-4539-AA15-FDC1E9AB03D1}
+		{5AA835F4-F265-403F-897C-8989E354C052} = {D623B9E7-6555-45AB-AAEC-EA388FACCE11}
 	EndGlobalSection
 EndGlobal

--- a/extensions/Bitwarden.Server.Sdk.Authentication/src/AuthenticationApplicationBuilderExtensions.cs
+++ b/extensions/Bitwarden.Server.Sdk.Authentication/src/AuthenticationApplicationBuilderExtensions.cs
@@ -1,0 +1,27 @@
+using Microsoft.AspNetCore.Builder;
+
+namespace Bitwarden.Server.Sdk.Authentication;
+
+/// <summary>
+/// Extension methods to add Bitwarden-style authentication to the HTTP application pipeline.
+/// </summary>
+public static class AuthenticationApplicationBuilderExtensions
+{
+    /// <summary>
+    /// Uses Bitwarden-style Authentication middleware.
+    /// This will always call <see cref="AuthAppBuilderExtensions.UseAuthentication"/> and all rules for that function
+    /// apply to this one. It should be called after <c>UseRouting</c> and before <c>UseAuthorization</c>.
+    /// </summary>
+    /// <param name="app">The <see cref="IApplicationBuilder"/> to add the middleware to.</param>
+    /// <returns>A reference to this instance after the operation has completed.</returns>
+    public static IApplicationBuilder UseBitwardenAuthentication(this IApplicationBuilder app)
+    {
+        ArgumentNullException.ThrowIfNull(app);
+
+        app.UseAuthentication();
+
+        app.UseMiddleware<PostAuthenticationLoggingMiddleware>();
+
+        return app;
+    }
+}

--- a/extensions/Bitwarden.Server.Sdk.Authentication/src/AuthenticationServiceCollectionExtensions.cs
+++ b/extensions/Bitwarden.Server.Sdk.Authentication/src/AuthenticationServiceCollectionExtensions.cs
@@ -1,0 +1,30 @@
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+
+namespace Bitwarden.Server.Sdk.Authentication;
+
+/// <summary>
+/// Extension methods for setting up Bitwarden-style authentication in a <see cref="IServiceCollection"/>.
+/// </summary>
+public static class AuthenticationServiceCollectionExtensions
+{
+    /// <summary>
+    /// Adds Bitwarden compatible authentication, can be configured through the `Authentication:Schemes:Bearer` config
+    /// section.
+    /// </summary>
+    /// <param name="services">The <see cref="IServiceCollection"/> to add the services to.</param>
+    /// <returns>The <see cref="IServiceCollection"/> for additional chaining.</returns>
+    public static IServiceCollection AddBitwardenAuthentication(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+            .AddJwtBearer();
+
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IConfigureOptions<JwtBearerOptions>, BitwardenConfigureJwtBearerOptions>());
+
+        return services;
+    }
+}

--- a/extensions/Bitwarden.Server.Sdk.Authentication/src/Bitwarden.Server.Sdk.Authentication.csproj
+++ b/extensions/Bitwarden.Server.Sdk.Authentication/src/Bitwarden.Server.Sdk.Authentication.csproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <VersionPrefix>0.1.0</VersionPrefix>
+    <PreReleaseVersionLabel>beta</PreReleaseVersionLabel>
+    <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
+    <VersionSuffix Condition="'$(VersionSuffix)' == '' AND '$(IsPreRelease)' == 'true'">$(PreReleaseVersionLabel).$(PreReleaseVersionIteration)</VersionSuffix>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.10" />
+  </ItemGroup>
+
+</Project>

--- a/extensions/Bitwarden.Server.Sdk.Authentication/src/BitwardenConfigureJwtBearerOptions.cs
+++ b/extensions/Bitwarden.Server.Sdk.Authentication/src/BitwardenConfigureJwtBearerOptions.cs
@@ -1,0 +1,53 @@
+using System.IdentityModel.Tokens.Jwt;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Logging;
+
+namespace Bitwarden.Server.Sdk.Authentication;
+
+internal class BitwardenConfigureJwtBearerOptions : IConfigureNamedOptions<JwtBearerOptions>
+{
+    private readonly IHostEnvironment _hostEnvironment;
+
+    public BitwardenConfigureJwtBearerOptions(IHostEnvironment hostEnvironment)
+    {
+        _hostEnvironment = hostEnvironment;
+
+        if (_hostEnvironment.IsDevelopment())
+        {
+            IdentityModelEventSource.ShowPII = true;
+        }
+    }
+
+    public void Configure(string? schemeName, JwtBearerOptions options)
+    {
+        if (schemeName != JwtBearerDefaults.AuthenticationScheme)
+        {
+            return;
+        }
+
+        // The MapInBoundClaims maps the Jwt claim names into the more microsoft standard of the same claims
+        // For example, the claim `"amr"` might exist in the JWT but with MapInboundClaims = true then once
+        // you get your hand on the ClaimsPrincipal you'd have to find the claim value using
+        // `ClaimTypes.AuthenticationMethod` or `"http://schemas.microsoft.com/claims/authnmethodsreferences"`
+        // Keeping the exact same name on the issuing side and the consumption side is less error prone in our
+        // opinion.
+        options.MapInboundClaims = false;
+
+        // Our identity service does not issue an audience claim for us to validate
+        options.TokenValidationParameters.ValidateAudience = false;
+
+        // This is the default AccessTokenJwtType that IdentityServer uses
+        options.TokenValidationParameters.ValidTypes = ["at+jwt"];
+
+        // Since we don't map inbound claims our if an email is going to exist
+        // it will be as a `"email"` claim.
+        options.TokenValidationParameters.NameClaimType = JwtRegisteredClaimNames.Email;
+    }
+
+    public void Configure(JwtBearerOptions options)
+    {
+        // Do nothing for unnamed options
+    }
+}

--- a/extensions/Bitwarden.Server.Sdk.Authentication/src/PostAuthenticationLoggingMiddleware.cs
+++ b/extensions/Bitwarden.Server.Sdk.Authentication/src/PostAuthenticationLoggingMiddleware.cs
@@ -1,0 +1,74 @@
+using System.Collections;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+
+namespace Bitwarden.Server.Sdk.Authentication;
+
+internal sealed class PostAuthenticationLoggingMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly ILogger<PostAuthenticationLoggingMiddleware> _logger;
+
+    public PostAuthenticationLoggingMiddleware(RequestDelegate next, ILogger<PostAuthenticationLoggingMiddleware> logger)
+    {
+        _next = next;
+        _logger = logger;
+    }
+
+    public Task Invoke(HttpContext context)
+    {
+        if (context.User.Identity == null || !context.User.Identity.IsAuthenticated)
+        {
+            return _next(context);
+        }
+
+        var subject = context.User.FindFirstValue(JwtRegisteredClaimNames.Sub);
+
+        if (string.IsNullOrEmpty(subject))
+        {
+            return _next(context);
+        }
+
+        using (_logger.BeginScope(new AuthenticatedUserLogScope(subject)))
+        {
+            return _next(context);
+        }
+    }
+
+    private sealed class AuthenticatedUserLogScope : IReadOnlyList<KeyValuePair<string, object>>
+    {
+        public string Subject { get; }
+
+        int IReadOnlyCollection<KeyValuePair<string, object>>.Count { get; } = 1;
+
+        KeyValuePair<string, object> IReadOnlyList<KeyValuePair<string, object>>.this[int index]
+        {
+            get
+            {
+                if (index == 0)
+                {
+                    return new KeyValuePair<string, object>(nameof(Subject), Subject);
+                }
+
+                throw new ArgumentOutOfRangeException(nameof(index));
+            }
+        }
+
+        public AuthenticatedUserLogScope(string subject)
+        {
+            Subject = subject;
+        }
+
+        IEnumerator<KeyValuePair<string, object>> IEnumerable<KeyValuePair<string, object>>.GetEnumerator()
+        {
+            yield return new KeyValuePair<string, object>(nameof(Subject), Subject);
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return ((IEnumerable<KeyValuePair<string, object>>)this).GetEnumerator();
+        }
+    }
+}

--- a/extensions/Bitwarden.Server.Sdk.Authentication/tests/Bitwarden.Server.Sdk.Authentication.Tests/AuthenticationServiceCollectionExtensionsTests.cs
+++ b/extensions/Bitwarden.Server.Sdk.Authentication/tests/Bitwarden.Server.Sdk.Authentication.Tests/AuthenticationServiceCollectionExtensionsTests.cs
@@ -1,0 +1,396 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Microsoft.IdentityModel.Tokens;
+using Xunit.Abstractions;
+
+namespace Bitwarden.Server.Sdk.Authentication.Tests;
+
+public class AuthenticationServiceCollectionExtensionsTests
+{
+    private readonly ITestOutputHelper _testOutputHelper;
+
+    public AuthenticationServiceCollectionExtensionsTests(ITestOutputHelper testOutputHelper)
+    {
+        _testOutputHelper = testOutputHelper;
+    }
+
+    [Fact]
+    public async Task AddBitwardenAuthentication_NoBearerToken_Unauthorized()
+    {
+        using var authHost = CreateAuthHost(out _);
+        await authHost.StartAsync();
+        using var appHost = CreateAppHost(authHost);
+        await appHost.StartAsync();
+
+        var client = appHost.GetTestClient();
+
+        var response = await client.GetAsync("/authed-user");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task AddBitwardenAuthentication_QueryString_DoesNotWork()
+    {
+        using var authHost = CreateAuthHost(out var certificate);
+        await authHost.StartAsync();
+        using var appHost = CreateAppHost(authHost);
+
+        await appHost.StartAsync();
+
+        var client = appHost.GetTestClient();
+
+        var accessToken = CreateAccessToken(certificate,
+            new JwtPayload(issuer: "http://localhost", audience: null, claims: null, notBefore: DateTime.UtcNow, expires: DateTime.UtcNow.AddDays(1)));
+
+        var response = await client.GetAsync($"/authed-user?access_token={accessToken}");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task AddBitwardenAuthentication_Header_Works()
+    {
+        using var authHost = CreateAuthHost(out var certificate);
+        await authHost.StartAsync();
+        using var appHost = CreateAppHost(authHost);
+
+        await appHost.StartAsync();
+
+        var client = appHost.GetTestClient();
+
+        var accessToken = CreateAccessToken(certificate,
+            new JwtPayload(issuer: "http://localhost", audience: null, claims: null, notBefore: DateTime.UtcNow, expires: DateTime.UtcNow.AddDays(1)));
+
+        var request = new HttpRequestMessage(HttpMethod.Get, "/authed-user");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+
+        var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task AddBitwardenAuthentication_DoesNotMapClaims()
+    {
+        using var authHost = CreateAuthHost(out var certificate);
+        await authHost.StartAsync();
+
+        using var appHost = CreateAppHost(authHost, configureServices: null,
+            endpoints =>
+            {
+                endpoints.MapGet("/test", (ClaimsPrincipal user) =>
+                {
+                    // Claim should NOT exist with its mapped name
+                    Assert.DoesNotContain(user.Claims, c => c.Type == ClaimTypes.AuthenticationMethod);
+                    // Claim SHOULD exist with it's original name
+                    var claim = Assert.Single(user.Claims, c => c.Type == JwtRegisteredClaimNames.Amr);
+                    return Results.Text(claim.Value);
+                });
+            }
+        );
+
+        await appHost.StartAsync();
+
+        var client = appHost.GetTestClient();
+
+        var accessToken = CreateAccessToken(certificate,
+            new JwtPayload(issuer: "http://localhost", audience: null, claims: [
+                new Claim(JwtRegisteredClaimNames.Amr, "test")
+            ], notBefore: DateTime.UtcNow, expires: DateTime.UtcNow.AddDays(1)));
+
+        var request = new HttpRequestMessage(HttpMethod.Get, "/test");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+        var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("test", await response.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task AddBitwardenAuthentication_UsesEmailForNameClaimType()
+    {
+        using var authHost = CreateAuthHost(out var certificate);
+        await authHost.StartAsync();
+
+        using var appHost = CreateAppHost(authHost, configureServices: null,
+            endpoints =>
+            {
+                endpoints.MapGet("/test", (ClaimsPrincipal user) =>
+                {
+                    Assert.NotNull(user.Identity);
+                    return Results.Text(user.Identity.Name);
+                });
+            }
+        );
+
+        await appHost.StartAsync();
+
+        var client = appHost.GetTestClient();
+
+        var accessToken = CreateAccessToken(certificate,
+            new JwtPayload(issuer: "http://localhost", audience: null, claims: [
+                new Claim(JwtRegisteredClaimNames.Email, "test@example.com")
+            ], notBefore: DateTime.UtcNow, expires: DateTime.UtcNow.AddDays(1)));
+
+        var request = new HttpRequestMessage(HttpMethod.Get, "/test");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+        var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("test@example.com", await response.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task AddBitwardenAuthentication_LogInEndpoint_ContainsScope()
+    {
+        using var authHost = CreateAuthHost(out var certificate);
+        await authHost.StartAsync();
+
+        using var appHost = CreateAppHost(authHost, configureServices: null,
+            endpoints =>
+            {
+                endpoints.MapGet("/test", (ILoggerFactory loggerFactory) =>
+                {
+                    loggerFactory.CreateLogger("Test").LogWarning("Hello world!");
+                });
+            }
+        );
+
+        await appHost.StartAsync();
+
+        var client = appHost.GetTestClient();
+
+        var accessToken = CreateAccessToken(certificate,
+            new JwtPayload(issuer: "http://localhost", audience: null, claims: [
+                new Claim(JwtRegisteredClaimNames.Sub, "user-subject")
+            ], notBefore: DateTime.UtcNow, expires: DateTime.UtcNow.AddDays(1)));
+
+        var request = new HttpRequestMessage(HttpMethod.Get, "/test");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+        var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var logCollector = appHost.Services.GetFakeLogCollector();
+        var logs = logCollector.GetSnapshot(true);
+        var myLog = Assert.Single(logs, l => l.Category == "Test" && l.Level == LogLevel.Warning && l.Message == "Hello world!");
+        Assert.Contains(myLog.Scopes.OfType<IEnumerable<KeyValuePair<string, object>>>(),
+            scope => scope.Any(kvp => kvp.Key == "Subject" && kvp.Value is string stringVal && stringVal == "user-subject")
+        );
+    }
+
+    private IHost CreateAppHost(
+        IHost authHost,
+        Action<IServiceCollection>? configureServices = null,
+        Action<IEndpointRouteBuilder>? configureEndpoints = null
+    )
+    {
+        return CreateHost(
+            (services) =>
+            {
+                services.AddBitwardenAuthentication();
+
+                if (authHost != null)
+                {
+                    // Shove in the auth host handler so that communication can be made to it.
+                    services.Configure<JwtBearerOptions>(JwtBearerDefaults.AuthenticationScheme, options =>
+                    {
+                        options.BackchannelHttpHandler = authHost.GetTestServer().CreateHandler();
+                    });
+                }
+
+                services.AddAuthorizationBuilder()
+                    .AddPolicy("authed-user", (policy) => policy.RequireAuthenticatedUser())
+                    .AddPolicy("simple-user", (policy) => policy.RequireAuthenticatedUser().RequireClaim("simple")
+                );
+
+                configureServices?.Invoke(services);
+            },
+            (app) =>
+            {
+                app.UseBitwardenAuthentication();
+                app.UseAuthorization();
+
+                app.UseEndpoints(endpoints =>
+                {
+                    endpoints.MapGet("/anonymous", () =>
+                    {
+                        return Results.Ok(new { Message = "Hi!" });
+                    })
+                        .AllowAnonymous();
+
+                    endpoints.MapGet("authed-user", () =>
+                    {
+                        return Results.Ok(new { Message = "You are authed!" });
+                    })
+                        .RequireAuthorization("authed-user");
+
+                    endpoints.MapGet("/simple-user", (ClaimsPrincipal user) =>
+                    {
+                        return Results.Ok(new { Message = $"Claim value: {user.FindFirstValue("simple")}" });
+                    })
+                        .RequireAuthorization("simple-user");
+
+                    configureEndpoints?.Invoke(endpoints);
+                });
+            },
+            new Dictionary<string, string?>
+            {
+                { "Authentication:Schemes:Bearer:Authority", "http://localhost" },
+                { "Authentication:Schemes:Bearer:RequireHttpsMetadata", "false" },
+            },
+            "App"
+        );
+    }
+
+    private static string CreateAccessToken(X509Certificate2 certificate, JwtPayload payload)
+    {
+        var handler = new JwtSecurityTokenHandler();
+        var token = new JwtSecurityToken(
+            new JwtHeader(new SigningCredentials(new X509SecurityKey(certificate), SecurityAlgorithms.RsaSha256), null, "at+jwt"),
+            payload
+        );
+        return handler.WriteToken(token);
+    }
+
+    private IHost CreateAuthHost(out X509Certificate2 certificate)
+    {
+        using var rsa = RSA.Create(2048);
+        var certRequest = new CertificateRequest($"CN=localhost", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        var selfSignedCert = certRequest.CreateSelfSigned(DateTimeOffset.UtcNow.AddYears(-1).AddMinutes(-1), DateTimeOffset.UtcNow.AddMinutes(-1));
+        certificate = selfSignedCert;
+
+        return CreateHost(
+            configureServices: null,
+            configureApplication: (app) =>
+            {
+                app.UseEndpoints(endpoints =>
+                {
+                    // Stub out the minimal things needed from an OpenId compatible server
+                    endpoints.MapGet("/.well-known/openid-configuration", () =>
+                    {
+                        return Results.Json(new OpenIdConnectConfiguration
+                        {
+                            Issuer = "http://localhost",
+                            JwksUri = "http://localhost/.well-known/openid-configuration/jwks",
+                        });
+                    });
+
+                    endpoints.MapGet("/.well-known/openid-configuration/jwks", () =>
+                    {
+                        var parameters = RSACertificateExtensions.GetRSAPublicKey(selfSignedCert)!.ExportParameters(false);
+                        var keySet = new JsonWebKeySet();
+                        keySet.Keys.Add(new JsonWebKey
+                        {
+                            Kty = JsonWebAlgorithmsKeyTypes.RSA,
+                            Use = "sig",
+                            Kid = selfSignedCert.Thumbprint + JsonWebAlgorithmsKeyTypes.RSA,
+                            X5t = Base64UrlEncoder.Encode(selfSignedCert.GetCertHash()),
+                            E = Base64UrlEncoder.Encode(parameters.Exponent),
+                            N = Base64UrlEncoder.Encode(parameters.Modulus),
+                            X5c = { Convert.ToBase64String(selfSignedCert.RawDataMemory.Span) },
+                            Alg = SecurityAlgorithms.RsaSha256,
+                        });
+                        return Results.Json(keySet);
+                    });
+                });
+            },
+            configuration: null,
+            "Auth"
+        );
+    }
+
+    private IHost CreateHost(
+        Action<IServiceCollection>? configureServices,
+        Action<IApplicationBuilder> configureApplication,
+        Dictionary<string, string?>? configuration,
+        string name
+    )
+    {
+        return new HostBuilder()
+            .UseEnvironment("Development")
+            .ConfigureAppConfiguration(builder =>
+            {
+                builder.AddInMemoryCollection(configuration);
+            })
+            .ConfigureWebHost((webHostBuilder) =>
+            {
+                webHostBuilder
+                    .UseTestServer()
+                    .ConfigureLogging(logging =>
+                    {
+                        logging.SetMinimumLevel(LogLevel.Trace);
+                        logging.AddProvider(new XUnitLoggerProvider(name, _testOutputHelper));
+                        logging.AddFakeLogging();
+                    })
+                    .ConfigureServices((context, services) =>
+                    {
+                        services.AddRouting();
+
+                        configureServices?.Invoke(services);
+                    })
+                    .Configure(app =>
+                    {
+                        app.UseRouting();
+
+                        configureApplication.Invoke(app);
+                    });
+            })
+            .Build();
+    }
+
+    public sealed class XUnitLoggerProvider : ILoggerProvider
+    {
+        private readonly string _name;
+        private readonly ITestOutputHelper _testOutputHelper;
+
+        public XUnitLoggerProvider(string name, ITestOutputHelper testOutputHelper)
+        {
+            _name = name;
+            _testOutputHelper = testOutputHelper;
+        }
+        public ILogger CreateLogger(string categoryName) => new XUnitLogger(_name, categoryName, _testOutputHelper);
+        public void Dispose() { }
+
+        private sealed class XUnitLogger : ILogger
+        {
+            private readonly string _name;
+            private readonly string _categoryName;
+            private readonly ITestOutputHelper _testOutputHelper;
+
+            public XUnitLogger(string name, string categoryName, ITestOutputHelper testOutputHelper)
+            {
+                _name = name;
+                _categoryName = categoryName;
+                _testOutputHelper = testOutputHelper;
+            }
+
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+            public bool IsEnabled(LogLevel logLevel)
+            {
+                return true;
+            }
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+            {
+                _testOutputHelper.WriteLine($"[{_name}][{_categoryName}] {formatter(state, exception)}");
+            }
+        }
+    }
+}

--- a/extensions/Bitwarden.Server.Sdk.Authentication/tests/Bitwarden.Server.Sdk.Authentication.Tests/Bitwarden.Server.Sdk.Authentication.Tests.csproj
+++ b/extensions/Bitwarden.Server.Sdk.Authentication/tests/Bitwarden.Server.Sdk.Authentication.Tests/Bitwarden.Server.Sdk.Authentication.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>Bitwarden.Server.Sdk.Authentication.Tests</RootNamespace>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="[6.0.4]" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="[17.13.0]" />
+    <PackageReference Include="xunit" Version="[2.9.3]" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="[3.0.2]" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="[8.0.15]" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="[9.9.0]" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Bitwarden.Server.Sdk.Authentication.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-12640

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Adds a `Bitwarden.Server.Sdk.Authentication` package that will be added to the server SDK once published. The code that this PR recreates is [this](https://github.com/bitwarden/server/blob/744f11733d838ae1d3a82fdc33ae1fcd368c21c0/src/SharedWeb/Utilities/ServiceCollectionExtensions.cs#L400-L436). It differs in a few very ways though.

- It doesn't take `Action<AuthorizationOptions>` instead consumers are expected to call `services.AddAuthorizationBuilder().AddPolicy("MyPolicy", ...)` in their own service collection. This has a couple benefits, one, this can more easily be consumed in the server SDK where the desired entrypoint there is ONLY `UseBitwardeSdk()` that takes no required arguments. Two, it keeps the concepts of Authorization and Authentication separate.
- It does NOT add a `OnMessageRecieved` handler that reads the token from the query string or the `Authorization` header. This is a pattern I don't think the server SDK should encourage. Reading the access token from a query parameter should only be done when absolutely necessary. Instead of allowing it on all requests we should allow it only on the specific hub methods that we want it. This is more inline with how [SignalR recommends it](https://learn.microsoft.com/en-us/aspnet/core/signalr/authn-and-authz?view=aspnetcore-9.0#built-in-jwt-authentication). 
- We change the `NameClaimType` to be `JwtRegisteredClaimTypes.Email` instead of `ClaimTypes.Email`. Since we don't map inbound claims and we definitely don't use `ClaimTypes.Email` anywhere in the access token this means that `ClaimsPrincipal.Identity.Name` always returns null. Now this will return the users email if an `email` claim was included in the access token. I can't find any use of the identity name in our server code but we can always override this back to that in server if we are worried.
- We have no mention of `Authority` or `RequireHttpsMetadata`. The SDK is going to not do any special handling here and instead encourage the use of the configuration section `Authentication:Schemes:Bearer` to configure those things (or through someone doing it in the code). `server` will need to do manual overriding to set those values from their pre-existing locations and logic. 

This registers the `JwtBearerHandler` with the default name `Bearer` AND registers it as the default authentication scheme. This matches what is always done in `server` but if we wanted to take a more hands-off approach we can register it with a name like `Bitwarden` and/or not register it as the default scheme. It would be up to users to decide what their default authentication scheme should be. Although that is already possible as long as they call `AddAuthentication("MyScheme")` after the call to `AddBitwardenAuthentication`. 


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
