### PR TITLE
Make Features and Authentication Aot Safe

### DIFF
--- a/extensions/Bitwarden.Server.Sdk.Authentication/src/Bitwarden.Server.Sdk.Authentication.csproj
+++ b/extensions/Bitwarden.Server.Sdk.Authentication/src/Bitwarden.Server.Sdk.Authentication.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/extensions/Bitwarden.Server.Sdk.Features/src/Bitwarden.Server.Sdk.Features.csproj
+++ b/extensions/Bitwarden.Server.Sdk.Features/src/Bitwarden.Server.Sdk.Features.csproj
@@ -4,6 +4,9 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <IsAotCompatible>true</IsAotCompatible>
+    <EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
+    <InterceptorsPreviewNamespaces>$(InterceptorsPreviewNamespaces);Microsoft.Extensions.Configuration.Binder.SourceGeneration</InterceptorsPreviewNamespaces>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/extensions/Bitwarden.Server.Sdk.Features/src/FeatureServiceCollectionExtensions.cs
+++ b/extensions/Bitwarden.Server.Sdk.Features/src/FeatureServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 using Bitwarden.Server.Sdk.Features;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using LaunchDarkly.Sdk.Server.Interfaces;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
@@ -89,7 +90,7 @@ public static class FeatureServiceCollectionExtensions
     /// <typeparam name="T">You custom implementation of <see cref="IContextBuilder"/>.</typeparam>
     /// <param name="services">The service collection to add the services to.</param>
     /// <returns>The <see cref="IServiceCollection" /> for additional chaining.</returns>
-    public static IServiceCollection AddContextBuilder<T>(this IServiceCollection services)
+    public static IServiceCollection AddContextBuilder<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(this IServiceCollection services)
         where T : class, IContextBuilder
     {
         ArgumentNullException.ThrowIfNull(services);


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Mark both the features package and the authentication package as AoT compatible. This enables more analyzers to make sure we are trim safe. 

Unfortunately the features package is not fully trim safe because it's bringing in libraries that are not trim safe. I have created issues/comments to hopefully get these resolved. 

https://github.com/launchdarkly/dotnet-sdk-internal/issues/49
https://github.com/launchdarkly/dotnet-core/issues/90#issuecomment-3338831170

The SDK is also bringing in `OpenTelemetry.Instrumentation.EntityFrameworkCore` which is not trim safe but EntityFrameworkCore itself isn't trim safe. I'm thinking we might just drop that dependency when we notice that someone is trying to publish in aot. With all those changes I think we could actually make https://github.com/bitwarden/billing-relay publish with AoT enabled.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
