### PR TITLE
Otel resource configuration

### DIFF
--- a/extensions/Bitwarden.Server.Sdk/src/Content/HostBuilderExtensions.cs
+++ b/extensions/Bitwarden.Server.Sdk/src/Content/HostBuilderExtensions.cs
@@ -53,7 +53,9 @@ public static class HostBuilderExtensions
     {
         hostBuilder.ConfigureAppConfiguration((context, builder) =>
         {
-            if (context.Configuration.GetValue(SelfHostedConfigKey, false))
+            // Legacy entrypoint does not yet have access to configuration with all environment variables
+            // so we need to search the environment ourselves.
+            if (string.Equals(Environment.GetEnvironmentVariable("globalSettings__selfHosted"), "true", StringComparison.OrdinalIgnoreCase))
             {
                 AddSelfHostedConfig(builder, context.HostingEnvironment);
             }

--- a/extensions/Bitwarden.Server.Sdk/src/Content/HostBuilderExtensions.cs
+++ b/extensions/Bitwarden.Server.Sdk/src/Content/HostBuilderExtensions.cs
@@ -114,22 +114,13 @@ public static class HostBuilderExtensions
             && environmentJsonSource.Path == $"appsettings.{environment.EnvironmentName}.json");
 
         // If both of those are true, I feel good about inserting our own self-hosted config after
-        configurationBuilder.Sources.Insert(4, new JsonConfigurationSource
+        configurationBuilder.Sources.Insert(i + 1, new JsonConfigurationSource
         {
             Path = "appsettings.SelfHosted.json",
             Optional = true,
             ReloadOnChange = true
         });
-
-        if (environment.IsDevelopment())
-        {
-            var appAssembly = Assembly.Load(new AssemblyName(environment.ApplicationName));
-            configurationBuilder.AddUserSecrets(appAssembly, optional: true);
-        }
-
-        configurationBuilder.AddEnvironmentVariables();
     }
-
 
     private static void AddMetrics(IServiceCollection services, IConfiguration configuration)
     {

--- a/extensions/Bitwarden.Server.Sdk/src/Content/HostBuilderExtensions.cs
+++ b/extensions/Bitwarden.Server.Sdk/src/Content/HostBuilderExtensions.cs
@@ -141,8 +141,6 @@ public static class HostBuilderExtensions
             !configuration.GetValue(SelfHostedConfigKey, false)
         );
 
-        Console.WriteLine($"OpenTelemetry Enabled: {openTelemetryEnabled}");
-
         services.AddOpenTelemetry()
             .ConfigureResource(r =>
             {

--- a/extensions/Bitwarden.Server.Sdk/tests/Bitwarden.Server.Sdk.IntegrationTests/SdkTests.cs
+++ b/extensions/Bitwarden.Server.Sdk/tests/Bitwarden.Server.Sdk.IntegrationTests/SdkTests.cs
@@ -431,7 +431,7 @@ public class SdkTests : MSBuildTestBase
         var (testOutput, _) = await testContainer.GetLogsAsync(ct: TestContext.Current.CancellationToken);
         loggerFactory.CreateLogger("TestOutput").LogInformation("{Stdout}", testOutput);
 
-        var (otelOutput, _) = await testContainer.GetLogsAsync(ct: TestContext.Current.CancellationToken);
+        var (otelOutput, _) = await otelContainer.GetLogsAsync(ct: TestContext.Current.CancellationToken);
         loggerFactory.CreateLogger("OtelOutput").LogInformation("{Stdout}", otelOutput);
 
         async Task<JsonDocument?> ReadDoc(string type)

--- a/extensions/Bitwarden.Server.Sdk/tests/Bitwarden.Server.Sdk.IntegrationTests/SdkTests.cs
+++ b/extensions/Bitwarden.Server.Sdk/tests/Bitwarden.Server.Sdk.IntegrationTests/SdkTests.cs
@@ -431,8 +431,9 @@ public class SdkTests : MSBuildTestBase
         var (testOutput, _) = await testContainer.GetLogsAsync(ct: TestContext.Current.CancellationToken);
         loggerFactory.CreateLogger("TestOutput").LogInformation("{Stdout}", testOutput);
 
-        var (otelOutput, _) = await otelContainer.GetLogsAsync(ct: TestContext.Current.CancellationToken);
+        var (otelOutput, otelError) = await otelContainer.GetLogsAsync(ct: TestContext.Current.CancellationToken);
         loggerFactory.CreateLogger("OtelOutput").LogInformation("{Stdout}", otelOutput);
+        loggerFactory.CreateLogger("OtelOutput").LogError("{Stderr}", otelError);
 
         async Task<JsonDocument?> ReadDoc(string type)
         {

--- a/extensions/Bitwarden.Server.Sdk/tests/Bitwarden.Server.Sdk.IntegrationTests/SdkTests.cs
+++ b/extensions/Bitwarden.Server.Sdk/tests/Bitwarden.Server.Sdk.IntegrationTests/SdkTests.cs
@@ -309,7 +309,8 @@ public class SdkTests : MSBuildTestBase
 
         await network.CreateAsync(TestContext.Current.CancellationToken);
 
-        // If the operating system is windows
+        // If the operating system is windows it's not running in CI most likely and
+        // likely not to have permissions issues.
         DirectoryInfo tempDir;
         if (!OperatingSystem.IsWindows())
         {

--- a/extensions/Bitwarden.Server.Sdk/tests/Bitwarden.Server.Sdk.IntegrationTests/SdkTests.cs
+++ b/extensions/Bitwarden.Server.Sdk/tests/Bitwarden.Server.Sdk.IntegrationTests/SdkTests.cs
@@ -428,6 +428,12 @@ public class SdkTests : MSBuildTestBase
         await testContainer.StopAsync(TestContext.Current.CancellationToken);
         await otelContainer.StopAsync(TestContext.Current.CancellationToken);
 
+        var (testOutput, _) = await testContainer.GetLogsAsync(ct: TestContext.Current.CancellationToken);
+        loggerFactory.CreateLogger("TestOutput").LogInformation("{Stdout}", testOutput);
+
+        var (otelOutput, _) = await testContainer.GetLogsAsync(ct: TestContext.Current.CancellationToken);
+        loggerFactory.CreateLogger("OtelOutput").LogInformation("{Stdout}", otelOutput);
+
         async Task<JsonDocument?> ReadDoc(string type)
         {
             var filePath = Path.Join(tempDir.FullName, $"{type}.json");

--- a/extensions/Bitwarden.Server.Sdk/tests/Bitwarden.Server.Sdk.IntegrationTests/SdkTests.cs
+++ b/extensions/Bitwarden.Server.Sdk/tests/Bitwarden.Server.Sdk.IntegrationTests/SdkTests.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 using DotNet.Testcontainers.Builders;
 using DotNet.Testcontainers.Containers;
@@ -308,7 +309,17 @@ public class SdkTests : MSBuildTestBase
 
         await network.CreateAsync(TestContext.Current.CancellationToken);
 
-        var tempDir = Directory.CreateTempSubdirectory();
+        // If the operating system is windows
+        DirectoryInfo tempDir;
+        if (!OperatingSystem.IsWindows())
+        {
+            tempDir = Directory.CreateDirectory(Path.GetTempPath(), UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.OtherWrite);
+        }
+        else
+        {
+            tempDir = Directory.CreateTempSubdirectory();
+        }
+
 
         await using var otelContainer = new ContainerBuilder()
             .WithImage("otel/opentelemetry-collector-contrib")


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Configure the otel resource service name with the application name by default. 

From this change I made a migration over to use the official otel collector for my test collector implementation. This means I can write tests on metrics collections instead of just traces like I was doing with jaeger. 

From some of these tests I discovered that my logic of inserting self hosted config wasn't working so I also fixed that.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
