### PR TITLE
Add options that can be configured to customize feature check failure

### DIFF
--- a/extensions/Bitwarden.Server.Sdk.Features/src/FeatureCheckFailureContext.cs
+++ b/extensions/Bitwarden.Server.Sdk.Features/src/FeatureCheckFailureContext.cs
@@ -1,0 +1,20 @@
+using Microsoft.AspNetCore.Http;
+
+namespace Bitwarden.Server.Sdk.Features;
+
+/// <summary>
+/// A context class for when a feature check was failed.
+/// </summary>
+public class FeatureCheckFailedContext
+{
+    /// <summary>
+    /// The <see cref="IFeatureMetadata"/> that failed their check and is the reason
+    /// <see cref="FeatureCheckOptions.OnFeatureCheckFailed"/> was called.
+    /// </summary>
+    public required IFeatureMetadata FailedMetadata { get; init; }
+
+    /// <summary>
+    /// The <see cref="HttpContext"/> of the current request.
+    /// </summary>
+    public required HttpContext HttpContext { get; init; }
+}

--- a/extensions/Bitwarden.Server.Sdk.Features/src/FeatureCheckOptions.cs
+++ b/extensions/Bitwarden.Server.Sdk.Features/src/FeatureCheckOptions.cs
@@ -1,0 +1,53 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Bitwarden.Server.Sdk.Features;
+
+/// <summary>
+/// A set of options for configuring how feature checks behave.
+/// </summary>
+public class FeatureCheckOptions
+{
+    /// <summary>
+    /// Invoked when a feature check on <see cref="IFeatureMetadata"/> fails. Defaults to writing failure to the
+    /// response using <see cref="ProblemDetails"/> format.
+    /// </summary>
+    public Func<FeatureCheckFailedContext, Task> OnFeatureCheckFailed { get; set; } = DefaultFeatureCheckFailedAsync;
+
+    private static async Task DefaultFeatureCheckFailedAsync(FeatureCheckFailedContext context)
+    {
+        var logger = context.HttpContext.RequestServices
+            .GetRequiredService<ILoggerFactory>()
+            .CreateLogger("Bitwarden.Server.Sdk.Features.FeatureCheck");
+        if (logger.IsEnabled(LogLevel.Debug))
+        {
+            logger.LogFailedFeatureCheck(context.FailedMetadata.ToString()!);
+        }
+
+        context.HttpContext.Response.StatusCode = StatusCodes.Status404NotFound;
+
+        var problemDetails = new ProblemDetails
+        {
+            Title = "Resource not found.",
+            Status = StatusCodes.Status404NotFound,
+        };
+
+        var hostEnvironment = context.HttpContext.RequestServices.GetRequiredService<IHostEnvironment>();
+        if (hostEnvironment.IsDevelopment())
+        {
+            // Add extra information
+            problemDetails.Detail = $"Feature check failed: {context.FailedMetadata}";
+        }
+
+        var problemDetailsService = context.HttpContext.RequestServices.GetRequiredService<IProblemDetailsService>();
+        // We don't really care if this fails, we will return the 404 no matter what.
+        await problemDetailsService.TryWriteAsync(new ProblemDetailsContext
+        {
+            HttpContext = context.HttpContext,
+            ProblemDetails = problemDetails,
+        });
+    }
+}

--- a/extensions/Bitwarden.Server.Sdk.Features/src/IFeatureMetadata.cs
+++ b/extensions/Bitwarden.Server.Sdk.Features/src/IFeatureMetadata.cs
@@ -1,11 +1,19 @@
-using System.ComponentModel;
-
 namespace Bitwarden.Server.Sdk.Features;
 
-internal interface IFeatureMetadata
+/// <summary>
+/// A piece of metadata that can be added to an endpoint to gate usage of that endpoint.
+/// </summary>
+public interface IFeatureMetadata
 {
     /// <summary>
-    /// A method to run to check if the feature is enabled.
+    /// A method to run to check if the feature is enabled. Should return <see langword="true" /> if the feature
+    /// can be used, returns <see langword="false" /> if not.
     /// </summary>
     Func<IFeatureService, bool> FeatureCheck { get; set; }
+
+    /// <summary>
+    /// Creats a display string that can be used in logs and development error messages for better debugging.
+    /// </summary>
+    /// <returns></returns>
+    string ToString();
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

In preparation of integrating a v1 into server I need to make the feature check response less opinionated. Right now it's forcing a problem details style response and that would be a breaking change for `server`. I am working on an ADR for switching the error format to problem details but for the sake of backwards compatibility I am opening up a customization point that server can use to keep their error format.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
