### PR TITLE
Create test dependency groups and remove parent dir grouping

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,8 +1,35 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>bitwarden/renovate-config"],
+  "extends": ["github>bitwarden/renovate-config:non-pinned"],
   "enabledManagers": ["github-actions", "nuget"],
   "packageRules": [
+    {
+      "groupName": "msbuild-packages",
+      "description": "MSBuild dependencies",
+      "commitMessagePrefix": "[deps] MSBuild:",
+      "matchPackageNames": [
+        "/^Microsoft.Build/"
+      ],
+      "matchUpdateTypes": ["patch"]
+    },
+    {
+      "groupName": "test-packages",
+      "description": "Dependencies used in test projects",
+      "commitMessagePrefix": "[deps] Test:",
+      "matchPackageNames": [
+        "coverlet.collector",
+        "Microsoft.AspNetCore.TestHost",
+        "Microsoft.NET.Test.Sdk",
+        "NSubstitute",
+        "xunit",
+        "xunit.v3",
+        "xunit.runner.visualstudio",
+        "Testcontainers",
+        "MSBuild.ProjectCreation",
+        "Microsoft.Extensions.Diagnostics.Testing"
+      ],
+      "matchUpdateTypes": ["patch", "minor"]
+    },
     {
       "matchManagers": ["nuget"],
       "rangeStrategy": "auto"
@@ -10,13 +37,6 @@
     {
       "groupName": "gh minor",
       "matchManagers": ["github-actions"],
-      "matchUpdateTypes": ["minor", "patch"]
-    },
-    {
-      "additionalBranchPrefix": "{{parentDir}}-",
-      "commitMessagePrefix": "[deps] {{parentDir}}:",
-      "groupName": "nuget minor",
-      "matchManagers": ["nuget"],
       "matchUpdateTypes": ["minor", "patch"]
     }
   ],


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Trying out a new renovate config for the repo.

First, it uses the `non-pinned` template config since these are all packages they should use the non-pinned behavior. 

Second, make a special group for `Microsoft.Build` related packages. Those package apparently drop supported frameworks in minor updates so having them in the rest of the test packages makes them annoying.

Third, make a group for test related dependencies. 

This hopefully means the rest of the packages will each get a PR by themselves, for now I think that is fine for this repo as there are relatively few deps in non-test projects.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
