### PR TITLE
Make it easy to integrate Bitwarden services with Aspire

### DIFF
--- a/extensions/Bitwarden.Server.Sdk/src/Content/HostBuilderExtensions.cs
+++ b/extensions/Bitwarden.Server.Sdk/src/Content/HostBuilderExtensions.cs
@@ -12,6 +12,9 @@ using OpenTelemetry.Resources;
 #if BIT_INCLUDE_CACHING
 using Bitwarden.Server.Sdk.Caching;
 #endif
+#if BIT_INCLUDE_TELEMETRY && BIT_INCLUDE_ASPIRE_INTEGRATION
+using OpenTelemetry.Logs;
+#endif
 
 namespace Microsoft.Extensions.Hosting;
 
@@ -49,6 +52,15 @@ public static class HostBuilderExtensions
 
 #if BIT_INCLUDE_CACHING
         builder.Services.AddBitwardenCaching();
+#endif
+
+#if BIT_INCLUDE_ASPIRE_INTEGRATION
+        builder.Services.AddServiceDiscovery();
+
+        builder.Services.ConfigureHttpClientDefaults(http =>
+        {
+            http.AddServiceDiscovery();
+        });
 #endif
 
         return builder;
@@ -94,6 +106,18 @@ public static class HostBuilderExtensions
         hostBuilder.ConfigureServices((_, services) =>
         {
             services.AddBitwardenCaching();
+        });
+#endif
+
+#if BIT_INCLUDE_ASPIRE_INTEGRATION
+        hostBuilder.ConfigureServices((_, services) =>
+        {
+            services.AddServiceDiscovery();
+
+            services.ConfigureHttpClientDefaults(http =>
+            {
+                http.AddServiceDiscovery();
+            });
         });
 #endif
 
@@ -186,6 +210,17 @@ public static class HostBuilderExtensions
                     });
                 }
             })
+#if BIT_INCLUDE_ASPIRE_INTEGRATION
+            .WithLogging(loggingBuilder =>
+            {
+                loggingBuilder.AddOtlpExporter();
+            },
+            loggingOptions =>
+            {
+                loggingOptions.IncludeFormattedMessage = true;
+                loggingOptions.IncludeScopes = true;
+            })
+#endif
             .WithMetrics(metrics =>
             {
                 if (configuration.GetValue<bool>("OpenTelemetry:Metrics:Enabled", openTelemetryEnabled))

--- a/extensions/Bitwarden.Server.Sdk/src/PACKAGE.md
+++ b/extensions/Bitwarden.Server.Sdk/src/PACKAGE.md
@@ -35,3 +35,19 @@ Enabled by default and able to be removed using
 This feature automatically includes the `Bitwarden.Server.Sdk.Authentication` library and when using
 the `Microsoft.NET.Sdk.Web` SDK it will register Bitwarden style authentication in
 `UseBitwardenSdk()`. All considerations of that package apply to this SDK.
+
+## Aspire Integration
+
+Disabled by default and able to be enabled using `<BitAspireIntegration>enabled</BitAspireIntegration>`
+in your project file.
+
+This feature adds service discovery support via `Microsoft.Extensions.ServiceDiscovery`, registering
+it into the `IServiceCollection` and configuring it as the default for all `HttpClient` instances.
+When telemetry is also enabled, OTLP log exporting is configured with formatted messages and scopes
+included.
+
+This is primarily useful for local development with .NET Aspire. To enable it only in debug builds:
+
+```xml
+<BitAspireIntegration Condition="'$(Configuration)' == 'Debug'">enabled</BitAspireIntegration>
+```

--- a/extensions/Bitwarden.Server.Sdk/src/Sdk/Sdk.targets
+++ b/extensions/Bitwarden.Server.Sdk/src/Sdk/Sdk.targets
@@ -34,6 +34,13 @@
     <!-- Caching defaults to off -->
     <BitIncludeCaching Condition="'$(BitIncludeCaching)' == ''">false</BitIncludeCaching>
     <DefineConstants Condition="'$(BitIncludeCaching)' == 'true'">$(DefineConstants);BIT_INCLUDE_CACHING</DefineConstants>
+
+    <!--
+      Aspire integration defaults to disabled
+      Valid options: disabled, enabled
+    -->
+    <BitAspireIntegration Condition="'$(BitAspireIntegration)' == ''">disabled</BitAspireIntegration>
+    <DefineConstants Condition="'$(BitAspireIntegration)' == 'enabled'">$(DefineConstants);BIT_INCLUDE_ASPIRE_INTEGRATION</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(BitIncludeTelemetry)' == 'true'">
@@ -62,5 +69,9 @@
 
   <ItemGroup Condition="'$(BitIncludeCaching)' == 'true'">
     <PackageReference Include="Bitwarden.Server.Sdk.Caching" Version="0.1.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(BitAspireIntegration)' == 'enabled'">
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.4.0" />
   </ItemGroup>
 </Project>

--- a/extensions/Bitwarden.Server.Sdk/tests/Bitwarden.Server.Sdk.IntegrationTests/SdkTests.cs
+++ b/extensions/Bitwarden.Server.Sdk/tests/Bitwarden.Server.Sdk.IntegrationTests/SdkTests.cs
@@ -165,20 +165,28 @@ public class SdkTests : MSBuildTestBase
 
     public static TheoryData<string> PossibleVariantData()
     {
-        string[] features = ["Telemetry", "Features", "Authentication", "Caching"];
-        var totalCombinations = (int)Math.Pow(2, features.Length);
+        var variations = new Dictionary<string, string[]>
+        {
+            { "BitIncludeTelemetry", ["true", "false"] },
+            { "BitIncludeFeatures", ["true", "false"] },
+            { "BitIncludeAuthentication", ["true", "false"] },
+            { "BitIncludeCaching", ["true", "false"] },
+            { "BitAspireIntegration", ["enabled", "disabled"] },
+        };
 
+        var keys = variations.Keys.ToArray();
         var theory = new TheoryData<string>();
 
-        for (var i = 0; i < totalCombinations; i++)
-        {
-            var variant = new Dictionary<string, bool>();
+        // Generate the cartesian product of all possible values for each property
+        IEnumerable<IEnumerable<string>> seed = [[]];
+        var combinations = variations.Values.Aggregate(seed, (acc, values) =>
+            from prev in acc
+            from value in values
+            select prev.Append(value));
 
-            for (var j = 0; j < features.Length; j++)
-            {
-                // Check if the j-th bit is set in i
-                variant[features[j]] = (i & (1 << j)) != 0;
-            }
+        foreach (var combination in combinations)
+        {
+            var variant = keys.Zip(combination).ToDictionary(kv => kv.First, kv => kv.Second);
 
             // TODO: When there are variants that need to be skipped do so here but still add
             // a row with a skip message
@@ -188,9 +196,9 @@ public class SdkTests : MSBuildTestBase
         return theory;
 
         // We serialize it into a simple string so that it can be easily viewed in test explorer
-        static string Serialize(Dictionary<string, bool> features)
+        static string Serialize(Dictionary<string, string> properties)
         {
-            return string.Join(',', features.Select(feature => $"{feature.Key}={feature.Value}"));
+            return string.Join(',', properties.Select(p => $"{p.Key}={p.Value}"));
         }
     }
 
@@ -198,12 +206,12 @@ public class SdkTests : MSBuildTestBase
     public void AllVariants_Work(string featureSets)
     {
         // Deserialize from simple string into dictionary
-        var features = featureSets.Split(",")
+        var properties = featureSets.Split(",")
             .Select(featureSet =>
             {
                 var split = featureSet.Split("=");
                 Debug.Assert(split.Length == 2, "Invalid format");
-                return new KeyValuePair<string, bool>(split[0], bool.Parse(split[1]));
+                return new KeyValuePair<string, string>(split[0], split[1]);
             })
             .ToDictionary();
 
@@ -212,9 +220,9 @@ public class SdkTests : MSBuildTestBase
             out var buildOutput,
             customAction: (project) =>
             {
-                foreach (var feature in features)
+                foreach (var property in properties)
                 {
-                    project.Property($"BitInclude{feature.Key}", feature.Value.ToString());
+                    project.Property(property.Key, property.Value);
                 }
             }
         );


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->


## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->


This adds a switch to the Bitwarden SDK that helps auto-integrate your service to be used with Aspire. It largely removes the need for the `ServiceDefaults` project that is scaffolded when using Aspire by default. The SDK already does OTel for metrics and traces which is the main thing the `ServiceDefaults` project does. This bridges the difference by using OTel for logs and configuring [`Microsoft.Extensions.ServiceDiscovery`](https://www.nuget.org/packages/Microsoft.Extensions.ServiceDiscovery). This does differ from from [this PR](https://github.com/bitwarden/server/pull/6775/changes#diff-1db28237f619d735f6df0fa502fade25e689fcd8abcf3e5954ad2544b106e559R157-R185) by not logging extra details about outgoing HTTP requests but I left the door open and would enable that later on via changing the property from `enabled` -> `debug`. 

I found writing tests for showing service discovery working pretty difficult and since I don't foresee this being a mission critical, likely only used in `Debug`, integration in the near future I am not beyond making sure things build. 

## 🚨 Breaking Changes

<!-- Does this PR introduce breaking changes for downstream .NET consumers? If yes, document them clearly.

If breaking changes exist:
1. Describe the public API, behavior, or configuration change
2. Explain why the change was necessary
3. Provide concrete migration steps for client developers
4. Link to any related or coordinated PRs/releases

If there are no breaking changes, delete this section. -->
