### PR TITLE
[PM-34913] Add WebEssentials library

### DIFF
--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -15,6 +15,7 @@ on:
           - Bitwarden.Server.Sdk.Caching
           - Bitwarden.Server.Sdk.Features
           - Bitwarden.Server.Sdk.HealthChecks
+          - Bitwarden.Server.Sdk.WebEssentials
 
 permissions: {}
 

--- a/bitwarden-dotnet.slnx
+++ b/bitwarden-dotnet.slnx
@@ -42,6 +42,12 @@
   <Folder Name="/extensions/Bitwarden.Server.Sdk.HealthChecks/tests/">
     <Project Path="extensions/Bitwarden.Server.Sdk.HealthChecks/tests/Bitwarden.Server.Sdk.HealthChecks.Tests/Bitwarden.Server.Sdk.HealthChecks.Tests.csproj" />
   </Folder>
+  <Folder Name="/extensions/Bitwarden.Server.Sdk.WebEssentials/">
+    <Project Path="extensions/Bitwarden.Server.Sdk.WebEssentials/src/Bitwarden.Server.Sdk.WebEssentials.csproj" />
+  </Folder>
+  <Folder Name="/extensions/Bitwarden.Server.Sdk.WebEssentials/tests/">
+    <Project Path="extensions/Bitwarden.Server.Sdk.WebEssentials/tests/Bitwarden.Server.Sdk.WebEssentials.Tests/Bitwarden.Server.Sdk.WebEssentials.Tests.csproj" />
+  </Folder>
   <Folder Name="/extensions/Bitwarden.Server.Sdk/">
     <Project Path="extensions/Bitwarden.Server.Sdk/src/Bitwarden.Server.Sdk.csproj" />
   </Folder>

--- a/extensions/Bitwarden.Server.Sdk.WebEssentials/src/Bitwarden.Server.Sdk.WebEssentials.csproj
+++ b/extensions/Bitwarden.Server.Sdk.WebEssentials/src/Bitwarden.Server.Sdk.WebEssentials.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <EnableRequestDelegateGenerator>true</EnableRequestDelegateGenerator>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <VersionPrefix>0.1.0</VersionPrefix>
+    <PreReleaseVersionLabel>beta</PreReleaseVersionLabel>
+    <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
+    <VersionSuffix Condition="'$(VersionSuffix)' == '' AND '$(IsPreRelease)' == 'true'">$(PreReleaseVersionLabel).$(PreReleaseVersionIteration)</VersionSuffix>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+</Project>

--- a/extensions/Bitwarden.Server.Sdk.WebEssentials/src/PACKAGE.md
+++ b/extensions/Bitwarden.Server.Sdk.WebEssentials/src/PACKAGE.md
@@ -1,0 +1,52 @@
+# Bitwarden.Server.Sdk.WebEssentials
+
+Shared web middleware and endpoint helpers for Bitwarden ASP.NET Core services.
+
+## Installation
+
+```shell
+dotnet add package Bitwarden.Server.Sdk.WebEssentials
+```
+
+## Setup
+
+Register services in `Program.cs`:
+
+```csharp
+builder.Services.AddWebEssentials();
+```
+
+## Security headers
+
+Call `UseSecurityHeaders()` early in your middleware pipeline to append common browser-security
+headers to every HTTP response:
+
+```csharp
+app.UseSecurityHeaders();
+```
+
+This adds the following headers to all responses:
+
+| Header | Value | Purpose |
+| --- | --- | --- |
+| `x-frame-options` | `SAMEORIGIN` | Prevents the page from being embedded in a cross-origin frame |
+| `x-xss-protection` | `1; mode=block` | Instructs legacy browsers to block reflected XSS attacks |
+| `x-content-type-options` | `nosniff` | Prevents MIME-type sniffing |
+
+## Version endpoint
+
+Call `MapVersionEndpoint()` to register a `GET /version` route that returns the application's
+version as JSON:
+
+```csharp
+app.MapVersionEndpoint();
+```
+
+Example response:
+
+```json
+{ "version": "1.2.3" }
+```
+
+The version is read from the application assembly's `AssemblyInformationalVersion`.
+Build metadata (e.g. the `+<git-hash>` suffix appended by the .NET SDK) is stripped automatically.

--- a/extensions/Bitwarden.Server.Sdk.WebEssentials/src/README.md
+++ b/extensions/Bitwarden.Server.Sdk.WebEssentials/src/README.md
@@ -1,0 +1,51 @@
+# Bitwarden.Server.Sdk.WebEssentials
+
+Shared web middleware and endpoint helpers for Bitwarden ASP.NET Core services.
+
+## Overview
+
+This package provides two features:
+
+- **Security headers middleware** — appends common browser-security HTTP headers to every response.
+- **Version endpoint** — maps a `GET /version` route that returns the application's `AssemblyInformationalVersion` as JSON.
+
+## Project structure
+
+```text
+src/                                        # Library
+  WebEssentialsServiceCollectionExtensions  # AddWebEssentials()
+  WebEssentialsApplicationBuilderExtensions # UseSecurityHeaders()
+  WebEssentialsEndpointRouteBuilderExtensions # MapVersionEndpoint()
+  SecurityHeadersMiddleware                 # Implementation
+  VersionResponse                           # Response DTO
+  WebEssentialsJsonSerializerContext        # Source-generated JSON context
+
+tests/
+  Bitwarden.Server.Sdk.WebEssentials.Tests         # Integration tests
+```
+
+## Security headers
+
+`SecurityHeadersMiddleware` appends three headers to every response:
+
+| Header | Value |
+| --- | --- |
+| `x-frame-options` | `SAMEORIGIN` |
+| `x-xss-protection` | `1; mode=block` |
+| `x-content-type-options` | `nosniff` |
+
+The values are stored as static `StringValues` fields to avoid per-request allocation.
+
+## Version endpoint
+
+`MapVersionEndpoint()` registers a `GET /version` route. The non-intercepted fallback resolves the
+version at registration time by loading the assembly identified by
+`IHostEnvironment.ApplicationName` and reading its `AssemblyInformationalVersionAttribute`. Build
+metadata (the `+<hash>` suffix appended by the SDK) is stripped before returning.
+
+## Adding or changing features
+
+- **New middleware**: add a class in `src/`, register it via a new extension method in `WebEssentialsApplicationBuilderExtensions`.
+- **New endpoints**: add an extension method in `WebEssentialsEndpointRouteBuilderExtensions`. If
+  the endpoint returns a new response type, add it to `WebEssentialsJsonSerializerContext` and
+  register the context with `ConfigureHttpJsonOptions` in `WebEssentialsServiceCollectionExtensions`.

--- a/extensions/Bitwarden.Server.Sdk.WebEssentials/src/SecurityHeadersMiddleware.cs
+++ b/extensions/Bitwarden.Server.Sdk.WebEssentials/src/SecurityHeadersMiddleware.cs
@@ -1,0 +1,34 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Primitives;
+
+namespace Bitwarden.Server.Sdk.WebEssentials;
+
+internal sealed class SecurityHeadersMiddleware
+{
+    private static readonly StringValues _frameOptionsHeaderValue = new("SAMEORIGIN");
+    private static readonly StringValues _xssProtectionHeaderValue = new("1; mode=block");
+    private static readonly StringValues _contentTypeOptionsHeaderValue = new("nosniff");
+
+    private readonly RequestDelegate _next;
+
+    public SecurityHeadersMiddleware(RequestDelegate next)
+    {
+        ArgumentNullException.ThrowIfNull(next);
+
+        _next = next;
+    }
+
+    public Task InvokeAsync(HttpContext context)
+    {
+        // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
+        context.Response.Headers.Append("x-frame-options", _frameOptionsHeaderValue);
+
+        // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection
+        context.Response.Headers.Append("x-xss-protection", _xssProtectionHeaderValue);
+
+        // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options
+        context.Response.Headers.Append("x-content-type-options", _contentTypeOptionsHeaderValue);
+
+        return _next(context);
+    }
+}

--- a/extensions/Bitwarden.Server.Sdk.WebEssentials/src/VersionResponse.cs
+++ b/extensions/Bitwarden.Server.Sdk.WebEssentials/src/VersionResponse.cs
@@ -1,0 +1,7 @@
+namespace Bitwarden.Server.Sdk.WebEssentials;
+
+/// <summary>
+/// Represents the response body returned by the <c>GET /version</c> endpoint.
+/// </summary>
+/// <param name="Version">The informational version of the entry assembly, or <see langword="null"/> if unavailable.</param>
+public sealed record VersionResponse(string? Version);

--- a/extensions/Bitwarden.Server.Sdk.WebEssentials/src/WebEssentialsApplicationBuilderExtensions.cs
+++ b/extensions/Bitwarden.Server.Sdk.WebEssentials/src/WebEssentialsApplicationBuilderExtensions.cs
@@ -1,4 +1,4 @@
-﻿using Bitwarden.Server.Sdk.WebEssentials;
+using Bitwarden.Server.Sdk.WebEssentials;
 
 namespace Microsoft.AspNetCore.Builder;
 

--- a/extensions/Bitwarden.Server.Sdk.WebEssentials/src/WebEssentialsApplicationBuilderExtensions.cs
+++ b/extensions/Bitwarden.Server.Sdk.WebEssentials/src/WebEssentialsApplicationBuilderExtensions.cs
@@ -1,0 +1,32 @@
+﻿using Bitwarden.Server.Sdk.WebEssentials;
+
+namespace Microsoft.AspNetCore.Builder;
+
+/// <summary>
+/// Extension methods for <see cref="IApplicationBuilder"/> provided by Bitwarden Web Essentials.
+/// </summary>
+public static class WebEssentialsApplicationBuilderExtensions
+{
+    /// <summary>
+    /// Adds middleware that appends common security headers to every HTTP response.
+    /// </summary>
+    /// <remarks>
+    /// This middleware should be registered in any project that exposes HTTP endpoints consumed by Bitwarden clients.
+    /// The following headers are added to all responses regardless of content type, including <c>application/json</c>:
+    /// <list type="bullet">
+    ///   <item><description><c>x-frame-options: SAMEORIGIN</c> — prevents the page from being embedded in a frame on a different origin.</description></item>
+    ///   <item><description><c>x-xss-protection: 1; mode=block</c> — instructs legacy browsers to block pages when a reflected XSS attack is detected.</description></item>
+    ///   <item><description><c>x-content-type-options: nosniff</c> — prevents browsers from MIME-sniffing a response away from the declared content type.</description></item>
+    /// </list>
+    /// </remarks>
+    /// <param name="app">The <see cref="IApplicationBuilder"/> to add the middleware to.</param>
+    /// <returns>The <see cref="IApplicationBuilder"/> so that calls can be chained.</returns>
+    public static IApplicationBuilder UseSecurityHeaders(this IApplicationBuilder app)
+    {
+        ArgumentNullException.ThrowIfNull(app);
+
+        app.UseMiddleware<SecurityHeadersMiddleware>();
+
+        return app;
+    }
+}

--- a/extensions/Bitwarden.Server.Sdk.WebEssentials/src/WebEssentialsEndpointRouteBuilderExtensions.cs
+++ b/extensions/Bitwarden.Server.Sdk.WebEssentials/src/WebEssentialsEndpointRouteBuilderExtensions.cs
@@ -1,0 +1,40 @@
+using System.Reflection;
+using Bitwarden.Server.Sdk.WebEssentials;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Microsoft.AspNetCore.Routing;
+
+/// <summary>
+/// Extension methods for <see cref="IEndpointRouteBuilder"/> provided by Bitwarden Web Essentials.
+/// </summary>
+public static class WebEssentialsEndpointRouteBuilderExtensions
+{
+    /// <summary>
+    /// Maps a <c>GET /version</c> endpoint that returns the informational version of the application assembly.
+    /// </summary>
+    /// <param name="endpoints">The <see cref="IEndpointRouteBuilder"/> to map the route on.</param>
+    /// <returns>An <see cref="IEndpointConventionBuilder"/> that can be used to further customize the endpoint.</returns>
+    public static IEndpointConventionBuilder MapVersionEndpoint(this IEndpointRouteBuilder endpoints)
+    {
+        ArgumentNullException.ThrowIfNull(endpoints);
+
+        var appName = endpoints.ServiceProvider.GetRequiredService<IHostEnvironment>().ApplicationName;
+        var version = ParseVersion(Assembly.Load(appName)
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+            ?.InformationalVersion);
+
+        return endpoints.MapGet("/version", () =>
+        {
+            return TypedResults.Ok(new VersionResponse(version));
+        });
+    }
+
+    private static string? ParseVersion(string? rawVersion)
+    {
+        var plusIdx = rawVersion?.IndexOf('+') ?? -1;
+        return plusIdx >= 0 ? rawVersion![..plusIdx] : rawVersion;
+    }
+}

--- a/extensions/Bitwarden.Server.Sdk.WebEssentials/src/WebEssentialsJsonSerializerContext.cs
+++ b/extensions/Bitwarden.Server.Sdk.WebEssentials/src/WebEssentialsJsonSerializerContext.cs
@@ -1,0 +1,6 @@
+using System.Text.Json.Serialization;
+
+namespace Bitwarden.Server.Sdk.WebEssentials;
+
+[JsonSerializable(typeof(VersionResponse))]
+internal sealed partial class WebEssentialsJsonSerializerContext : JsonSerializerContext { }

--- a/extensions/Bitwarden.Server.Sdk.WebEssentials/src/WebEssentialsServiceCollectionExtensions.cs
+++ b/extensions/Bitwarden.Server.Sdk.WebEssentials/src/WebEssentialsServiceCollectionExtensions.cs
@@ -1,0 +1,27 @@
+using Bitwarden.Server.Sdk.WebEssentials;
+
+namespace Microsoft.Extensions.DependencyInjection;
+
+/// <summary>
+/// Extension methods for configuring Bitwarden Web Essentials services.
+/// </summary>
+public static class WebEssentialsServiceCollectionExtensions
+{
+    /// <summary>
+    /// Adds services required by Bitwarden Web Essentials, including JSON serialization metadata
+    /// for types used by endpoints registered via <see cref="Microsoft.AspNetCore.Routing.WebEssentialsEndpointRouteBuilderExtensions.MapVersionEndpoint(AspNetCore.Routing.IEndpointRouteBuilder)"/>.
+    /// </summary>
+    /// <param name="services">The <see cref="IServiceCollection"/> to add services to.</param>
+    /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
+    public static IServiceCollection AddWebEssentials(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.ConfigureHttpJsonOptions(options =>
+        {
+            options.SerializerOptions.TypeInfoResolverChain.Add(WebEssentialsJsonSerializerContext.Default);
+        });
+
+        return services;
+    }
+}

--- a/extensions/Bitwarden.Server.Sdk.WebEssentials/tests/Bitwarden.Server.Sdk.WebEssentials.Tests/Bitwarden.Server.Sdk.WebEssentials.Tests.csproj
+++ b/extensions/Bitwarden.Server.Sdk.WebEssentials/tests/Bitwarden.Server.Sdk.WebEssentials.Tests/Bitwarden.Server.Sdk.WebEssentials.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <!--
+    This template uses native xUnit.net command line options when using 'dotnet run' and
+    VSTest by default when using 'dotnet test'. For more information on how to enable support
+    for Microsoft Testing Platform, please visit:
+      https://xunit.net/docs/getting-started/v3/microsoft-testing-platform
+    -->
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="[18.0.4]" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="[8.0.20]" />
+    <PackageReference Include="xunit.v3" Version="[3.1.0]" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/Bitwarden.Server.Sdk.WebEssentials.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/extensions/Bitwarden.Server.Sdk.WebEssentials/tests/Bitwarden.Server.Sdk.WebEssentials.Tests/WebEssentialsApplicationBuilderExtensionsTests.cs
+++ b/extensions/Bitwarden.Server.Sdk.WebEssentials/tests/Bitwarden.Server.Sdk.WebEssentials.Tests/WebEssentialsApplicationBuilderExtensionsTests.cs
@@ -1,0 +1,45 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Bitwarden.Server.Sdk.WebEssentials.Tests;
+
+public class WebEssentialsApplicationBuilderExtensionsTests
+{
+    [Fact]
+    public async Task UseSecurityHeaders_Works()
+    {
+        using var app = BuildApp(() => Results.Ok("Hello"));
+        await app.StartAsync(TestContext.Current.CancellationToken);
+
+        var response = await app.GetTestClient().GetAsync("", TestContext.Current.CancellationToken);
+
+        AssertSecurityHeadersPresent(response);
+    }
+
+    private static WebApplication BuildApp(Func<IResult> handler)
+    {
+        var builder = WebApplication.CreateEmptyBuilder(new WebApplicationOptions());
+        builder.Services.AddRoutingCore();
+        builder.WebHost.UseTestServer();
+
+        var app = builder.Build();
+        app.UseSecurityHeaders();
+        app.MapGet("/", handler);
+
+        return app;
+    }
+
+    private static void AssertSecurityHeadersPresent(HttpResponseMessage response)
+    {
+        Assert.True(response.Headers.TryGetValues("x-frame-options", out var frameOptions));
+        Assert.Equal("SAMEORIGIN", Assert.Single(frameOptions));
+
+        Assert.True(response.Headers.TryGetValues("x-xss-protection", out var xssProtections));
+        Assert.Equal("1; mode=block", Assert.Single(xssProtections));
+
+        Assert.True(response.Headers.TryGetValues("x-content-type-options", out var contentTypeOptions));
+        Assert.Equal("nosniff", Assert.Single(contentTypeOptions));
+    }
+}

--- a/extensions/Bitwarden.Server.Sdk.WebEssentials/tests/Bitwarden.Server.Sdk.WebEssentials.Tests/WebEssentialsEndpointRouteBuilderExtensionsTests.cs
+++ b/extensions/Bitwarden.Server.Sdk.WebEssentials/tests/Bitwarden.Server.Sdk.WebEssentials.Tests/WebEssentialsEndpointRouteBuilderExtensionsTests.cs
@@ -1,0 +1,37 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Bitwarden.Server.Sdk.WebEssentials.Tests;
+
+public class WebEssentialsEndpointRouteBuilderExtensionsTests
+{
+    [Fact]
+    public async Task MapVersionEndpoint_ReturnsVersionJson()
+    {
+        using var app = BuildApp();
+        await app.StartAsync(TestContext.Current.CancellationToken);
+
+        var response = await app.GetTestClient().GetAsync("/version", TestContext.Current.CancellationToken);
+        var json = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+
+        using var doc = JsonDocument.Parse(json);
+        Assert.True(doc.RootElement.TryGetProperty("version", out var versionElement));
+        Assert.True(Version.TryParse(versionElement.GetString(), out _));
+    }
+
+    private static WebApplication BuildApp()
+    {
+        var builder = WebApplication.CreateEmptyBuilder(new WebApplicationOptions());
+        builder.Services.AddRoutingCore();
+        builder.Services.AddWebEssentials();
+        builder.WebHost.UseTestServer();
+
+        var app = builder.Build();
+        app.MapVersionEndpoint();
+
+        return app;
+    }
+}


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-34913

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Implements a couple of core features in `server` to its own lib so that these things can be shared without necessarily using the `Core` project. 

This does change the version endpoint compared to what the project produce right now, as far as I can tell we have no automation that relies on the output of the endpoint but I will validate that before switching any project to this new endpoint. If there is any fear of breaking changes we can switch this to just returning `"1.2.3"` but I'd rather do an object to support adding more details like the commit hash in the future.


## 🚨 Breaking Changes

<!-- Does this PR introduce breaking changes for downstream .NET consumers? If yes, document them clearly.

If breaking changes exist:
1. Describe the public API, behavior, or configuration change
2. Explain why the change was necessary
3. Provide concrete migration steps for client developers
4. Link to any related or coordinated PRs/releases

If there are no breaking changes, delete this section. -->
