### PR TITLE
Switch to JSON string version endpoint response

### DIFF
--- a/extensions/Bitwarden.Server.Sdk.WebEssentials/src/VersionResponse.cs
+++ b/extensions/Bitwarden.Server.Sdk.WebEssentials/src/VersionResponse.cs
@@ -1,7 +1,0 @@
-namespace Bitwarden.Server.Sdk.WebEssentials;
-
-/// <summary>
-/// Represents the response body returned by the <c>GET /version</c> endpoint.
-/// </summary>
-/// <param name="Version">The informational version of the entry assembly, or <see langword="null"/> if unavailable.</param>
-public sealed record VersionResponse(string? Version);

--- a/extensions/Bitwarden.Server.Sdk.WebEssentials/src/WebEssentialsEndpointRouteBuilderExtensions.cs
+++ b/extensions/Bitwarden.Server.Sdk.WebEssentials/src/WebEssentialsEndpointRouteBuilderExtensions.cs
@@ -28,7 +28,7 @@ public static class WebEssentialsEndpointRouteBuilderExtensions
 
         return endpoints.MapGet("/version", () =>
         {
-            return TypedResults.Ok(new VersionResponse(version));
+            return TypedResults.Ok(version);
         });
     }
 

--- a/extensions/Bitwarden.Server.Sdk.WebEssentials/src/WebEssentialsEndpointRouteBuilderExtensions.cs
+++ b/extensions/Bitwarden.Server.Sdk.WebEssentials/src/WebEssentialsEndpointRouteBuilderExtensions.cs
@@ -1,5 +1,4 @@
 using System.Reflection;
-using Bitwarden.Server.Sdk.WebEssentials;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;

--- a/extensions/Bitwarden.Server.Sdk.WebEssentials/src/WebEssentialsJsonSerializerContext.cs
+++ b/extensions/Bitwarden.Server.Sdk.WebEssentials/src/WebEssentialsJsonSerializerContext.cs
@@ -2,5 +2,5 @@ using System.Text.Json.Serialization;
 
 namespace Bitwarden.Server.Sdk.WebEssentials;
 
-[JsonSerializable(typeof(VersionResponse))]
+[JsonSerializable(typeof(string))]
 internal sealed partial class WebEssentialsJsonSerializerContext : JsonSerializerContext { }

--- a/extensions/Bitwarden.Server.Sdk.WebEssentials/tests/Bitwarden.Server.Sdk.WebEssentials.Tests/WebEssentialsEndpointRouteBuilderExtensionsTests.cs
+++ b/extensions/Bitwarden.Server.Sdk.WebEssentials/tests/Bitwarden.Server.Sdk.WebEssentials.Tests/WebEssentialsEndpointRouteBuilderExtensionsTests.cs
@@ -18,8 +18,8 @@ public class WebEssentialsEndpointRouteBuilderExtensionsTests
         var json = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
         using var doc = JsonDocument.Parse(json);
-        Assert.True(doc.RootElement.TryGetProperty("version", out var versionElement));
-        Assert.True(Version.TryParse(versionElement.GetString(), out _));
+        Assert.Equal(JsonValueKind.String, doc.RootElement.ValueKind);
+        Assert.True(Version.TryParse(doc.RootElement.GetString(), out _));
     }
 
     private static WebApplication BuildApp()


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

Relates to: [ARCH-16](https://bitwarden.atlassian.net/browse/ARCH-16)
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Switch the version endpoint that here to match the return shape of what the version endpoints in server use. I much prefer
using an object so that it allows us to grow the response but even though I can't find anyone internally who relies on the
current shape I'd really rather not rock that boat right now and would rather start using this library sooner so I can stop
relying on `Core` for the version.

## 🚨 Breaking Changes

<!-- Does this PR introduce breaking changes for downstream .NET consumers? If yes, document them clearly.

If breaking changes exist:
1. Describe the public API, behavior, or configuration change
2. Explain why the change was necessary
3. Provide concrete migration steps for client developers
4. Link to any related or coordinated PRs/releases

If there are no breaking changes, delete this section. -->


[ARCH-16]: https://bitwarden.atlassian.net/browse/ARCH-16?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ