### PR TITLE
Add required permissions to workflows

### DIFF
--- a/.github/workflows/pack-and-release.yml
+++ b/.github/workflows/pack-and-release.yml
@@ -93,6 +93,7 @@ jobs:
     needs: release
     uses: bitwarden/dotnet-extensions/.github/workflows/version-bump.yml@main
     permissions:
+      contents: read
       id-token: write
     with:
       type: ${{ inputs.prerelease && 'prerelease' || 'hotfix' }}

--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -57,6 +57,7 @@ jobs:
     needs: start-release
     uses: bitwarden/dotnet-extensions/.github/workflows/version-bump.yml@main
     permissions:
+      contents: read
       id-token: write
     with:
       type: ga


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

The `.github/workflows/version-bump.yml` requires the `contents: read` permission so it the `start-release` action failed for me when I tried to run it. I believe it would have failed for start-release as well so I added it there.

https://github.com/bitwarden/dotnet-extensions/actions/runs/28257878005

## 🚨 Breaking Changes

<!-- Does this PR introduce breaking changes for downstream .NET consumers? If yes, document them clearly.

If breaking changes exist:
1. Describe the public API, behavior, or configuration change
2. Explain why the change was necessary
3. Provide concrete migration steps for client developers
4. Link to any related or coordinated PRs/releases

If there are no breaking changes, delete this section. -->
