### PR TITLE
Add WebEssentials into server SDK

### DIFF
--- a/extensions/Bitwarden.Server.Sdk/src/Content/HostBuilderExtensions.cs
+++ b/extensions/Bitwarden.Server.Sdk/src/Content/HostBuilderExtensions.cs
@@ -54,6 +54,10 @@ public static class HostBuilderExtensions
         builder.Services.AddBitwardenCaching();
 #endif
 
+#if BIT_INCLUDE_WEB_ESSENTIALS
+        builder.Services.AddWebEssentials();
+#endif
+
 #if BIT_INCLUDE_ASPIRE_INTEGRATION
         builder.Services.AddServiceDiscovery();
 
@@ -106,6 +110,13 @@ public static class HostBuilderExtensions
         hostBuilder.ConfigureServices((_, services) =>
         {
             services.AddBitwardenCaching();
+        });
+#endif
+
+#if BIT_INCLUDE_WEB_ESSENTIALS
+        hostBuilder.ConfigureServices((_, services) =>
+        {
+            services.AddWebEssentials();
         });
 #endif
 

--- a/extensions/Bitwarden.Server.Sdk/src/PACKAGE.md
+++ b/extensions/Bitwarden.Server.Sdk/src/PACKAGE.md
@@ -36,6 +36,20 @@ This feature automatically includes the `Bitwarden.Server.Sdk.Authentication` li
 the `Microsoft.NET.Sdk.Web` SDK it will register Bitwarden style authentication in
 `UseBitwardenSdk()`. All considerations of that package apply to this SDK.
 
+## Web Essentials
+
+Enabled by default and able to be removed using `<BitIncludeWebEssentials>false</BitIncludeWebEssentials>`
+in your project file.
+
+This feature automatically includes the `Bitwarden.Server.Sdk.WebEssentials` library and registers
+its services in `UseBitwardenSdk()`. All considerations of that package apply to this SDK.
+
+To add the security headers middleware, call `UseSecurityHeaders()` on your application builder:
+
+```csharp
+app.UseSecurityHeaders();
+```
+
 ## Aspire Integration
 
 Disabled by default and able to be enabled using `<BitAspireIntegration>enabled</BitAspireIntegration>`

--- a/extensions/Bitwarden.Server.Sdk/src/Sdk/Sdk.targets
+++ b/extensions/Bitwarden.Server.Sdk/src/Sdk/Sdk.targets
@@ -34,6 +34,9 @@
     <!-- Caching defaults to off -->
     <BitIncludeCaching Condition="'$(BitIncludeCaching)' == ''">false</BitIncludeCaching>
     <DefineConstants Condition="'$(BitIncludeCaching)' == 'true'">$(DefineConstants);BIT_INCLUDE_CACHING</DefineConstants>
+    <!-- WebEssentials defaults to on -->
+    <BitIncludeWebEssentials Condition="'$(BitIncludeWebEssentials)' == ''">true</BitIncludeWebEssentials>
+    <DefineConstants Condition="'$(BitIncludeWebEssentials)' == 'true'">$(DefineConstants);BIT_INCLUDE_WEB_ESSENTIALS</DefineConstants>
 
     <!--
       Aspire integration defaults to disabled
@@ -69,6 +72,10 @@
 
   <ItemGroup Condition="'$(BitIncludeCaching)' == 'true'">
     <PackageReference Include="Bitwarden.Server.Sdk.Caching" Version="0.1.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(BitIncludeWebEssentials)' == 'true'">
+    <PackageReference Include="Bitwarden.Server.Sdk.WebEssentials" Version="0.4.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(BitAspireIntegration)' == 'enabled'">

--- a/extensions/Bitwarden.Server.Sdk/tests/Bitwarden.Server.Sdk.IntegrationTests/SdkTests.cs
+++ b/extensions/Bitwarden.Server.Sdk/tests/Bitwarden.Server.Sdk.IntegrationTests/SdkTests.cs
@@ -14,6 +14,7 @@ public class SdkTests : MSBuildTestBase
             ("FEATURES", true),
             ("AUTHENTICATION", true),
             ("CACHING", false),
+            ("WEB_ESSENTIALS", true),
         ];
 
         var project = ProjectCreator.Templates.SdkProject(out var result, out var buildOutput);
@@ -172,6 +173,7 @@ public class SdkTests : MSBuildTestBase
             { "BitIncludeAuthentication", ["true", "false"] },
             { "BitIncludeCaching", ["true", "false"] },
             { "BitAspireIntegration", ["enabled", "disabled"] },
+            { "BitIncludeWebEssentials", ["true", "false"] },
         };
 
         var keys = variations.Keys.ToArray();


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

Part of: https://bitwarden.atlassian.net/browse/PM-34564

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

This adds the newly published `Bitwarden.Server.Sdk.WebEssentials` package to be automatically available when using the server SDK. It is easily turned off if not needed though. Most importantly it makes it so that you can drop the dependency on `Core` for security headers middleware and for your `/version` endpoint. 

## 🚨 Breaking Changes

<!-- Does this PR introduce breaking changes for downstream .NET consumers? If yes, document them clearly.

If breaking changes exist:
1. Describe the public API, behavior, or configuration change
2. Explain why the change was necessary
3. Provide concrete migration steps for client developers
4. Link to any related or coordinated PRs/releases

If there are no breaking changes, delete this section. -->
