### PR TITLE
Add configuration-driven FusionCache options binding

### DIFF
--- a/extensions/Bitwarden.Server.Sdk.Caching/src/ConfigureFusionCacheOptions.cs
+++ b/extensions/Bitwarden.Server.Sdk.Caching/src/ConfigureFusionCacheOptions.cs
@@ -1,10 +1,20 @@
+using System.Globalization;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
 using ZiggyCreatures.Caching.Fusion;
+using static Bitwarden.Server.Sdk.Caching.ConfigHelpers;
 
 namespace Bitwarden.Server.Sdk.Caching;
 
 internal sealed class ConfigureFusionCacheOptions : IConfigureNamedOptions<FusionCacheOptions>
 {
+    private readonly IConfiguration _configuration;
+
+    public ConfigureFusionCacheOptions(IConfiguration configuration)
+    {
+        _configuration = configuration;
+    }
+
     public void Configure(string? name, FusionCacheOptions options)
     {
         if (name == null || name == Options.DefaultName)
@@ -14,6 +24,64 @@ internal sealed class ConfigureFusionCacheOptions : IConfigureNamedOptions<Fusio
 
         options.CacheName = name;
         options.CacheKeyPrefix = $"{name}:";
+
+        var useFusion = _configuration.GetSection($"Caching:Uses:{name}:Fusion");
+        var defaultFusion = _configuration.GetSection("Caching:Fusion");
+
+        // FusionCacheOptions-level settings
+        if (TryGetDefinedValue(useFusion, defaultFusion, nameof(options.DistributedCacheCircuitBreakerDuration), out string? cbStr)
+            && TimeSpan.TryParse(cbStr, out var cb))
+            options.DistributedCacheCircuitBreakerDuration = cb;
+
+        // DefaultEntryOptions settings
+        var useEntry = useFusion.GetSection(nameof(options.DefaultEntryOptions));
+        var defaultEntry = defaultFusion.GetSection(nameof(options.DefaultEntryOptions));
+        var entry = options.DefaultEntryOptions;
+
+        if (TryGetDefinedValue(useEntry, defaultEntry, nameof(entry.Duration), out string? durationStr)
+            && TimeSpan.TryParse(durationStr, out var duration))
+            entry.Duration = duration;
+
+        if (TryGetDefinedValue(useEntry, defaultEntry, nameof(entry.IsFailSafeEnabled), out string? failSafeStr)
+            && bool.TryParse(failSafeStr, out var isFailSafeEnabled))
+            entry.IsFailSafeEnabled = isFailSafeEnabled;
+
+        if (TryGetDefinedValue(useEntry, defaultEntry, nameof(entry.FailSafeMaxDuration), out string? fsmStr)
+            && TimeSpan.TryParse(fsmStr, out var failSafeMax))
+            entry.FailSafeMaxDuration = failSafeMax;
+
+        if (TryGetDefinedValue(useEntry, defaultEntry, nameof(entry.FailSafeThrottleDuration), out string? fstStr)
+            && TimeSpan.TryParse(fstStr, out var failSafeThrottle))
+            entry.FailSafeThrottleDuration = failSafeThrottle;
+
+        // null is intentional: explicitly setting EagerRefreshThreshold to null disables eager refresh
+        if (TryGetDefinedValue(useEntry, defaultEntry, nameof(entry.EagerRefreshThreshold), out string? ertStr))
+            entry.EagerRefreshThreshold = ertStr is null ? null
+                : float.TryParse(ertStr, CultureInfo.InvariantCulture, out var ert) ? ert : entry.EagerRefreshThreshold;
+
+        if (TryGetDefinedValue(useEntry, defaultEntry, nameof(entry.FactorySoftTimeout), out string? fsoStr)
+            && TimeSpan.TryParse(fsoStr, out var factorySoft))
+            entry.FactorySoftTimeout = factorySoft;
+
+        if (TryGetDefinedValue(useEntry, defaultEntry, nameof(entry.FactoryHardTimeout), out string? fhoStr)
+            && TimeSpan.TryParse(fhoStr, out var factoryHard))
+            entry.FactoryHardTimeout = factoryHard;
+
+        if (TryGetDefinedValue(useEntry, defaultEntry, nameof(entry.DistributedCacheSoftTimeout), out string? dsoStr)
+            && TimeSpan.TryParse(dsoStr, out var distSoft))
+            entry.DistributedCacheSoftTimeout = distSoft;
+
+        if (TryGetDefinedValue(useEntry, defaultEntry, nameof(entry.DistributedCacheHardTimeout), out string? dhoStr)
+            && TimeSpan.TryParse(dhoStr, out var distHard))
+            entry.DistributedCacheHardTimeout = distHard;
+
+        if (TryGetDefinedValue(useEntry, defaultEntry, nameof(entry.AllowBackgroundDistributedCacheOperations), out string? bgStr)
+            && bool.TryParse(bgStr, out var bgOps))
+            entry.AllowBackgroundDistributedCacheOperations = bgOps;
+
+        if (TryGetDefinedValue(useEntry, defaultEntry, nameof(entry.JitterMaxDuration), out string? jitterStr)
+            && TimeSpan.TryParse(jitterStr, out var jitter))
+            entry.JitterMaxDuration = jitter;
     }
 
     public void Configure(FusionCacheOptions options)

--- a/extensions/Bitwarden.Server.Sdk.Caching/src/PACKAGE.md
+++ b/extensions/Bitwarden.Server.Sdk.Caching/src/PACKAGE.md
@@ -10,7 +10,7 @@ implements the decision outcome of
 ## Usage
 
 ```c#
-public class MyService([FromKeyed("MyFeature")]IFusionCache cache, IDatabase database)
+public class MyService([FromKeyedServices("MyFeature")] IFusionCache cache, IDatabase database)
 {
     public async Task<Thing> GetAsync(string id)
     {
@@ -19,38 +19,200 @@ public class MyService([FromKeyed("MyFeature")]IFusionCache cache, IDatabase dat
 }
 ```
 
-Inject a named `IFusionCache` instance using keyed services. No additional setup is required. See
-`AddBitwardenCaching` for complete customization documentation.
+Inject a named `IFusionCache` instance using keyed services. No additional setup is required beyond
+registering caching in your host. See `AddBitwardenCaching` for complete customization documentation.
+
+## Deployment Modes
+
+The package supports three deployment modes, determined at runtime by which services are registered:
+
+### Memory + Redis (recommended for cloud/multi-instance)
+
+When a Redis connection string is configured, each named cache gets its own `FusionCache` instance
+backed by Redis as L2 and a Redis backplane for cross-instance invalidation.
+
+```csharp
+services.AddBitwardenCaching();
+// Configure Redis via appsettings:
+// Caching:Redis:Configuration = "redis.example.com:6379,ssl=true,password=..."
+```
+
+### Memory + Custom Distributed Cache
+
+When no Redis is configured but a non-keyed `IDistributedCache` is registered, it is used as L2.
+This path covers SQL Server or EF cache in self-hosted deployments, and supports the persistent
+Cosmos DB keyed cache pattern (see [Pairing with Cosmos DB](#pairing-with-cosmos-db) below). No
+backplane is available without Redis — L1 entries on other instances expire on their own TTL.
+
+```csharp
+// SQL Server cache (self-hosted):
+services.AddDistributedSqlServerCache(options => { ... });
+services.AddBitwardenCaching();
+```
+
+### Memory-only (development, testing, or single-instance)
+
+To use memory-only caching — with all of FusionCache's stampede protection, fail-safe, and eager
+refresh benefits but no distributed layer — register an in-process `IDistributedCache`:
+
+```csharp
+// Memory-backed IDistributedCache: no Redis, no network, no shared state across instances.
+services.AddDistributedMemoryCache();
+services.AddBitwardenCaching();
+```
+
+> **Note**: `AddBitwardenCaching` requires a non-keyed `IDistributedCache` or Redis configuration.
+> Without either, resolving an `IFusionCache` instance throws `InvalidOperationException`. This is
+> intentional: misconfiguration surfaces at startup rather than silently degrading to process-local
+> caching in a multi-instance environment.
 
 ## Customization
 
 ### FusionCacheOptions
 
-The most common customization point for libraries is `FusionCacheOptions`. Customize using named
-options:
+The most common customization point is `FusionCacheOptions`. Use named options to configure a
+specific cache:
 
 ```c#
 services.Configure<FusionCacheOptions>("MyFeature", options =>
 {
     options.DefaultEntryOptions.Duration = TimeSpan.FromSeconds(10);
+    options.DefaultEntryOptions.IsFailSafeEnabled = true;
+    options.DefaultEntryOptions.FailSafeMaxDuration = TimeSpan.FromHours(1);
+    options.DefaultEntryOptions.EagerRefreshThreshold = 0.9f; // Refresh at 90% of TTL
+});
+```
+
+Or use `ConfigureAll` to apply defaults to every named cache (useful for migrating from a legacy
+settings object):
+
+```csharp
+services.ConfigureAll<FusionCacheOptions>(opts =>
+{
+    opts.DefaultEntryOptions.Duration = legacySettings.CacheDuration;
+    opts.DefaultEntryOptions.IsFailSafeEnabled = legacySettings.IsFailSafeEnabled;
 });
 ```
 
 ### IDistributedCache
 
-Customize the backend used for `IDistributedCache`:
+Override the distributed cache backend for a specific named cache:
 
 ```c#
 services.TryAddKeyedSingleton<IDistributedCache, MyCustomCache>("MyFeature");
 ```
 
 By default, `IDistributedCache` uses Redis when configured, falling back to a non-keyed
-`IDistributedCache` registration. Hosts may provide alternate globally configured instances. For
-example, a host may register a keyed `IDistributedCache` with key `"persistent"` that uses CosmosDB
-instead of Redis. Use that cache for your feature:
+`IDistributedCache` registration. User-registered keyed instances take precedence over both.
 
-```c#
-services.TryAddKeyedSingleton("MyFeature",
-    (s, _) => s.GetRequiredKeyedService<IDistributedCache>("persistent")
-);
+#### Pairing with Cosmos DB
+
+The server registers a `"persistent"` keyed `IDistributedCache` backed by Cosmos DB for
+long-lived data. To use it as L2 under `IFusionCache`, alias it under your cache name before
+calling `AddBitwardenCaching`:
+
+```csharp
+// Register the persistent (Cosmos) keyed cache first:
+services.AddDistributedCache(globalSettings);
+
+// Alias it under your cache name so AddBitwardenCaching picks it up:
+services.TryAddKeyedSingleton("MyLongLivedCache",
+    (sp, _) => sp.GetRequiredKeyedService<IDistributedCache>("persistent"));
+
+services.AddBitwardenCaching();
+services.Configure<FusionCacheOptions>("MyLongLivedCache", options =>
+{
+    options.DefaultEntryOptions.Duration = TimeSpan.FromHours(24);
+});
 ```
+
+Note: Cosmos does not support a backplane. L1 entries on other instances are not invalidated on
+write — they expire on their own TTL.
+
+### MemoryCacheOptions
+
+Customize the per-cache `IMemoryCache` using named options:
+
+```csharp
+services.Configure<MemoryCacheOptions>("MyFeature", options =>
+{
+    options.TrackStatistics = true;
+});
+```
+
+## Configuration Schema
+
+All settings support a global default (applied to every cache) and per-cache overrides. Per-cache
+values take precedence over the global default.
+
+```json
+{
+  "Caching": {
+    "Redis": {
+      "Configuration": "redis.example.com:6379,ssl=true,password=...",
+      "InstanceName": "optional-key-prefix:"
+    },
+    "Fusion": {
+      "DistributedCacheCircuitBreakerDuration": "00:00:05",
+      "DefaultEntryOptions": {
+        "Duration": "00:05:00",
+        "IsFailSafeEnabled": true,
+        "FailSafeMaxDuration": "01:00:00",
+        "FailSafeThrottleDuration": "00:00:30",
+        "EagerRefreshThreshold": "0.9",
+        "FactorySoftTimeout": "00:00:01",
+        "FactoryHardTimeout": "00:00:05",
+        "DistributedCacheSoftTimeout": "00:00:02",
+        "DistributedCacheHardTimeout": "00:00:10",
+        "AllowBackgroundDistributedCacheOperations": true,
+        "JitterMaxDuration": "00:00:05"
+      }
+    },
+    "Uses": {
+      "MyFeature": {
+        "Redis": {
+          "Configuration": "override-redis:6379",
+          "InstanceName": "myfeature:"
+        },
+        "Fusion": {
+          "DefaultEntryOptions": {
+            "Duration": "00:10:00",
+            "IsFailSafeEnabled": false,
+            "EagerRefreshThreshold": null
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Set `EagerRefreshThreshold` to `null` (or omit it) to disable background eager refresh for a
+specific cache.
+
+## Testing
+
+For unit tests, register an in-process `IDistributedCache` — no Redis container needed:
+
+```csharp
+[Fact]
+public async Task CacheHit_ReturnsCachedValue()
+{
+    var services = new ServiceCollection();
+    services.AddLogging();
+    services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+    services.AddDistributedMemoryCache();  // memory-only, no Redis required
+    services.AddBitwardenCaching();
+
+    var provider = services.BuildServiceProvider();
+    var cache = provider.GetRequiredKeyedService<IFusionCache>("MyFeature");
+
+    await cache.SetAsync("key", "value");
+    var result = await cache.GetOrDefaultAsync<string>("key");
+
+    Assert.Equal("value", result);
+}
+```
+
+For integration tests that exercise the Redis backplane, use Testcontainers to spin up a real
+Redis instance (see the package's own test suite for an example using `RedisFixture`).

--- a/extensions/Bitwarden.Server.Sdk.Caching/tests/Bitwarden.Server.Sdk.Caching.Tests/BitwardenCachingServiceCollectionExtensionsTests.cs
+++ b/extensions/Bitwarden.Server.Sdk.Caching/tests/Bitwarden.Server.Sdk.Caching.Tests/BitwardenCachingServiceCollectionExtensionsTests.cs
@@ -312,6 +312,25 @@ public class BitwardenCachingServiceCollectionExtensionsTests : IClassFixture<Re
     }
 
     [Fact]
+    public async Task MemoryDistributedCache_WorksAsMemoryOnlyMode()
+    {
+        // Demonstrates the memory-only pattern: register MemoryDistributedCache when no Redis is
+        // available (e.g. local development, unit tests, or single-instance deployments).
+        // This gives the full FusionCache feature set (stampede protection, fail-safe, eager
+        // refresh) with an in-process L2 and no backplane.
+        var services = Create([]);
+        services.AddDistributedMemoryCache();
+        services.AddBitwardenCaching();
+
+        var provider = services.BuildServiceProvider();
+        var cache = provider.GetRequiredKeyedService<IFusionCache>("Test");
+
+        await cache.SetAsync("Key", "Value", token: TestContext.Current.CancellationToken);
+        var result = await cache.GetOrDefaultAsync<string>("Key", token: TestContext.Current.CancellationToken);
+        Assert.Equal("Value", result);
+    }
+
+    [Fact]
     public async Task RedisNotConfigured_NonKeyedDistributedCacheAdded_Works()
     {
         var services = Create([]);

--- a/extensions/Bitwarden.Server.Sdk.Caching/tests/Bitwarden.Server.Sdk.Caching.Tests/BitwardenCachingServiceCollectionExtensionsTests.cs
+++ b/extensions/Bitwarden.Server.Sdk.Caching/tests/Bitwarden.Server.Sdk.Caching.Tests/BitwardenCachingServiceCollectionExtensionsTests.cs
@@ -43,6 +43,31 @@ public class BitwardenCachingServiceCollectionExtensionsTests : IClassFixture<Re
     }
 
     [Fact]
+    public void MultipleCaches_EachGetsIsolatedBackplane()
+    {
+        var provider = CreateProvider(new Dictionary<string, string?>
+        {
+            {"Caching:Redis:Configuration", _redis.Hostname},
+        });
+
+        var cacheA = provider.GetRequiredKeyedService<IFusionCache>("CacheA");
+        var cacheB = provider.GetRequiredKeyedService<IFusionCache>("CacheB");
+
+        // Both caches must actually have a backplane wired up.
+        Assert.True(cacheA.HasBackplane);
+        Assert.True(cacheB.HasBackplane);
+
+        // Each cache must get its own backplane instance. A RedisBackplane is bound to a single
+        // pub/sub channel at subscribe time; sharing one instance across named caches collapses
+        // them all onto whichever channel subscribed last, misrouting cross-instance invalidations.
+        // Regression guard for: https://github.com/bitwarden/server/pull/8004
+        var backplaneA = provider.GetRequiredKeyedService<IFusionCacheBackplane>("CacheA");
+        var backplaneB = provider.GetRequiredKeyedService<IFusionCacheBackplane>("CacheB");
+
+        Assert.NotSame(backplaneA, backplaneB);
+    }
+
+    [Fact]
     public async Task ValueRoundTrips()
     {
         var provider = CreateProvider(new Dictionary<string, string?>
@@ -127,6 +152,99 @@ public class BitwardenCachingServiceCollectionExtensionsTests : IClassFixture<Re
         var redisThree = redisOptions.Get("Three");
         Assert.Null(redisThree.Configuration);
         Assert.Null(redisThree.InstanceName);
+    }
+
+    [Fact]
+    public void AppliesDefaultEntryOptionDefaults()
+    {
+        var provider = CreateProvider(new Dictionary<string, string?>
+        {
+            // FusionCacheOptions-level setting
+            {"Caching:Fusion:DistributedCacheCircuitBreakerDuration", "00:00:10"},
+            // Global DefaultEntryOptions defaults applied to all caches
+            {"Caching:Fusion:DefaultEntryOptions:Duration", "00:05:00"},
+            {"Caching:Fusion:DefaultEntryOptions:IsFailSafeEnabled", "true"},
+            {"Caching:Fusion:DefaultEntryOptions:FailSafeMaxDuration", "01:00:00"},
+            {"Caching:Fusion:DefaultEntryOptions:FailSafeThrottleDuration", "00:00:30"},
+            {"Caching:Fusion:DefaultEntryOptions:EagerRefreshThreshold", "0.9"},
+            {"Caching:Fusion:DefaultEntryOptions:FactorySoftTimeout", "00:00:01"},
+            {"Caching:Fusion:DefaultEntryOptions:FactoryHardTimeout", "00:00:05"},
+            {"Caching:Fusion:DefaultEntryOptions:DistributedCacheSoftTimeout", "00:00:02"},
+            {"Caching:Fusion:DefaultEntryOptions:DistributedCacheHardTimeout", "00:00:10"},
+            {"Caching:Fusion:DefaultEntryOptions:AllowBackgroundDistributedCacheOperations", "true"},
+            {"Caching:Fusion:DefaultEntryOptions:JitterMaxDuration", "00:00:05"},
+            // "Two" overrides Duration and IsFailSafeEnabled; rest inherited from global
+            {"Caching:Uses:Two:Fusion:DefaultEntryOptions:Duration", "00:10:00"},
+            {"Caching:Uses:Two:Fusion:DefaultEntryOptions:IsFailSafeEnabled", "false"},
+            // "Three" explicitly disables EagerRefreshThreshold (null = opt out of eager refresh)
+            {"Caching:Uses:Three:Fusion:DefaultEntryOptions:EagerRefreshThreshold", null},
+        });
+
+        var fusionOptions = provider.GetRequiredService<IOptionsMonitor<FusionCacheOptions>>();
+
+        // "One" inherits all global defaults
+        var one = fusionOptions.Get("One");
+        Assert.Equal(TimeSpan.FromSeconds(10), one.DistributedCacheCircuitBreakerDuration);
+        var entryOne = one.DefaultEntryOptions;
+        Assert.Equal(TimeSpan.FromMinutes(5), entryOne.Duration);
+        Assert.True(entryOne.IsFailSafeEnabled);
+        Assert.Equal(TimeSpan.FromHours(1), entryOne.FailSafeMaxDuration);
+        Assert.Equal(TimeSpan.FromSeconds(30), entryOne.FailSafeThrottleDuration);
+        Assert.Equal(0.9f, entryOne.EagerRefreshThreshold);
+        Assert.Equal(TimeSpan.FromSeconds(1), entryOne.FactorySoftTimeout);
+        Assert.Equal(TimeSpan.FromSeconds(5), entryOne.FactoryHardTimeout);
+        Assert.Equal(TimeSpan.FromSeconds(2), entryOne.DistributedCacheSoftTimeout);
+        Assert.Equal(TimeSpan.FromSeconds(10), entryOne.DistributedCacheHardTimeout);
+        Assert.True(entryOne.AllowBackgroundDistributedCacheOperations);
+        Assert.Equal(TimeSpan.FromSeconds(5), entryOne.JitterMaxDuration);
+
+        // "Two" overrides Duration and IsFailSafeEnabled, inherits the rest from global
+        var entryTwo = fusionOptions.Get("Two").DefaultEntryOptions;
+        Assert.Equal(TimeSpan.FromMinutes(10), entryTwo.Duration);
+        Assert.False(entryTwo.IsFailSafeEnabled);
+        Assert.Equal(TimeSpan.FromHours(1), entryTwo.FailSafeMaxDuration);
+        Assert.Equal(0.9f, entryTwo.EagerRefreshThreshold);
+
+        // "Three" explicitly sets EagerRefreshThreshold to null, disabling eager refresh
+        var entryThree = fusionOptions.Get("Three").DefaultEntryOptions;
+        Assert.Null(entryThree.EagerRefreshThreshold);
+    }
+
+    [Fact]
+    public void DefaultEntryOptions_CanBeMappedFromLegacySettings()
+    {
+        // Demonstrates how callers can map from an existing settings object (e.g. GlobalSettings)
+        // to FusionCacheOptions using ConfigureAll, which applies defaults to every named cache
+        // without needing to migrate to the Caching:Fusion:* configuration section.
+        var services = Create([]);
+
+        services.AddBitwardenCaching();
+
+        var legacy = new LegacyCacheSettings
+        {
+            Duration = TimeSpan.FromMinutes(10),
+            IsFailSafeEnabled = true,
+            FailSafeMaxDuration = TimeSpan.FromHours(2),
+        };
+
+        services.ConfigureAll<FusionCacheOptions>(opts =>
+        {
+            opts.DefaultEntryOptions.Duration = legacy.Duration;
+            opts.DefaultEntryOptions.IsFailSafeEnabled = legacy.IsFailSafeEnabled;
+            opts.DefaultEntryOptions.FailSafeMaxDuration = legacy.FailSafeMaxDuration;
+        });
+
+        var provider = services.BuildServiceProvider();
+        var fusionOptions = provider.GetRequiredService<IOptionsMonitor<FusionCacheOptions>>();
+
+        // Defaults are applied to every cache, not just a specific named instance
+        foreach (var name in new[] { "CacheA", "CacheB" })
+        {
+            var options = fusionOptions.Get(name);
+            Assert.Equal(TimeSpan.FromMinutes(10), options.DefaultEntryOptions.Duration);
+            Assert.True(options.DefaultEntryOptions.IsFailSafeEnabled);
+            Assert.Equal(TimeSpan.FromHours(2), options.DefaultEntryOptions.FailSafeMaxDuration);
+        }
     }
 
     [Fact]
@@ -376,31 +494,29 @@ public class BitwardenCachingServiceCollectionExtensionsTests : IClassFixture<Re
         var value = await fusionTwo.GetOrDefaultAsync("Key", false, token: TestContext.Current.CancellationToken);
         Assert.True(value);
 
-        // Setup a task that completes once the second instance recieves a message through its backplane
-        var tcs = new TaskCompletionSource();
         var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
         if (!Debugger.IsAttached)
         {
             cts.CancelAfter(TimeSpan.FromSeconds(2));
         }
 
-        fusionTwo.Events.Backplane.MessageReceived += async (sender, args) =>
+        // Setup a task that completes once the second instance has updated its local memory cache
+        // from the distributed cache. FusionCache proactively fetches the new value from Redis and
+        // writes it to local memory when it processes the backplane EntrySet notification, firing
+        // Events.Memory.Set — which is the definitive signal that the new value is available locally.
+        var memorySetTcs = new TaskCompletionSource();
+        fusionTwo.Events.Memory.Set += (sender, args) =>
         {
-            if (args.Message.Action != BackplaneMessageAction.EntrySet || args.Message.CacheKey != "Test:Key")
+            if (args.Key == "Test:Key")
             {
-                return;
+                memorySetTcs.TrySetResult();
             }
-
-            tcs.TrySetResult();
         };
 
         await fusionOne.SetAsync("Key", false, token: cts.Token);
 
-        // Wait for the second instance to receive the message the the first instance had a value change
-        await tcs.Task;
-        // Give it just a moment to set the value to the memory store, I could change this to wait for that event if this
-        // proves to be flakey.
-        await Task.Delay(TimeSpan.FromMilliseconds(10), TestContext.Current.CancellationToken);
+        // Wait for the second instance to update its local memory from the distributed cache (via backplane)
+        await memorySetTcs.Task.WaitAsync(cts.Token);
 
         value = await fusionTwo.GetOrDefaultAsync("Key", true, token: cts.Token);
 
@@ -496,6 +612,13 @@ public class BitwardenCachingServiceCollectionExtensionsTests : IClassFixture<Re
         var services = Create(initialData);
         services.AddBitwardenCaching();
         return services.BuildServiceProvider();
+    }
+
+    private sealed class LegacyCacheSettings
+    {
+        public TimeSpan Duration { get; set; }
+        public bool IsFailSafeEnabled { get; set; }
+        public TimeSpan FailSafeMaxDuration { get; set; }
     }
 
     public class FakeDistributedCache : IDistributedCache


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

Binds `FusionCacheOptions` and `DefaultEntryOptions` from `IConfiguration` using the existing two-tier global (`Caching:Fusion:*`) / per-cache (`Caching:Uses:{name}:Fusion:*`) lookup pattern already established by `ConfigureRedisCacheOptions`.

Also fixes a flaky integration test in `MultipleInstances_Works` by replacing a timing-dependent `Task.Delay(10ms)` with a deterministic `Memory.Set` event signal.