### PR TITLE
Update LaunchDarkly.ServerSdk to 8.14.1

### DIFF
--- a/extensions/Bitwarden.Server.Sdk.Features/src/Bitwarden.Server.Sdk.Features.csproj
+++ b/extensions/Bitwarden.Server.Sdk.Features/src/Bitwarden.Server.Sdk.Features.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="LaunchDarkly.ServerSdk" Version="8.12.0" />
+    <PackageReference Include="LaunchDarkly.ServerSdk" Version="8.14.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/extensions/Bitwarden.Server.Sdk.Features/src/packages.lock.json
+++ b/extensions/Bitwarden.Server.Sdk.Features/src/packages.lock.json
@@ -4,13 +4,13 @@
     "net8.0": {
       "LaunchDarkly.ServerSdk": {
         "type": "Direct",
-        "requested": "[8.12.0, )",
-        "resolved": "8.12.0",
-        "contentHash": "ZxX2F4pZhHIuskgZqPGv2UoSVcPbwW7vsTZQWcg/tDaS3sw0ykgNhmSlE1rzf1l4Lsz/JBKtfKQLIo6A9tNm7A==",
+        "requested": "[8.14.1, )",
+        "resolved": "8.14.1",
+        "contentHash": "ufdAP+8OYpLEnDJanErS7wXj9xRYKCY1ZXmxaYuQwTB0qik3DviMRy5ml6Ehjd8kGgWZzOnur5EwqTKM+wW/AQ==",
         "dependencies": {
           "LaunchDarkly.Cache": "1.0.2",
           "LaunchDarkly.CommonSdk": "7.2.0",
-          "LaunchDarkly.EventSource": "5.3.0",
+          "LaunchDarkly.EventSource": "5.3.1",
           "LaunchDarkly.InternalSdk": "3.6.1",
           "LaunchDarkly.Logging": "2.0.0"
         }
@@ -36,8 +36,8 @@
       },
       "LaunchDarkly.EventSource": {
         "type": "Transitive",
-        "resolved": "5.3.0",
-        "contentHash": "i++YvdrzvTc1tOxfVreU2yjo/E+iTFcVtwiB4PZ/3uTouNdhABLbJfz1jmGN3jmnvJKWhsMeEZLZM0dzkI+PXQ==",
+        "resolved": "5.3.1",
+        "contentHash": "bVXethnjYnjC+hYSHYhn+1QFZhwtD0NYy1MJjtfOfC6CBW9h1pzR0hEAf16DQYl/LJtMi7fwOJbQhq8lFlFrSw==",
         "dependencies": {
           "LaunchDarkly.Logging": "[2.0.0, 3.0.0)"
         }

--- a/extensions/Bitwarden.Server.Sdk.Features/tests/Bitwarden.Server.Sdk.Features.Analyzers.Tests/packages.lock.json
+++ b/extensions/Bitwarden.Server.Sdk.Features/tests/Bitwarden.Server.Sdk.Features.Analyzers.Tests/packages.lock.json
@@ -77,8 +77,8 @@
       },
       "LaunchDarkly.EventSource": {
         "type": "Transitive",
-        "resolved": "5.3.0",
-        "contentHash": "i++YvdrzvTc1tOxfVreU2yjo/E+iTFcVtwiB4PZ/3uTouNdhABLbJfz1jmGN3jmnvJKWhsMeEZLZM0dzkI+PXQ==",
+        "resolved": "5.3.1",
+        "contentHash": "bVXethnjYnjC+hYSHYhn+1QFZhwtD0NYy1MJjtfOfC6CBW9h1pzR0hEAf16DQYl/LJtMi7fwOJbQhq8lFlFrSw==",
         "dependencies": {
           "LaunchDarkly.Logging": "[2.0.0, 3.0.0)"
         }
@@ -102,12 +102,12 @@
       },
       "LaunchDarkly.ServerSdk": {
         "type": "Transitive",
-        "resolved": "8.12.0",
-        "contentHash": "ZxX2F4pZhHIuskgZqPGv2UoSVcPbwW7vsTZQWcg/tDaS3sw0ykgNhmSlE1rzf1l4Lsz/JBKtfKQLIo6A9tNm7A==",
+        "resolved": "8.14.1",
+        "contentHash": "ufdAP+8OYpLEnDJanErS7wXj9xRYKCY1ZXmxaYuQwTB0qik3DviMRy5ml6Ehjd8kGgWZzOnur5EwqTKM+wW/AQ==",
         "dependencies": {
           "LaunchDarkly.Cache": "1.0.2",
           "LaunchDarkly.CommonSdk": "7.2.0",
-          "LaunchDarkly.EventSource": "5.3.0",
+          "LaunchDarkly.EventSource": "5.3.1",
           "LaunchDarkly.InternalSdk": "3.6.1",
           "LaunchDarkly.Logging": "2.0.0"
         }
@@ -810,7 +810,7 @@
       "bitwarden.server.sdk.features": {
         "type": "Project",
         "dependencies": {
-          "LaunchDarkly.ServerSdk": "[8.12.0, )"
+          "LaunchDarkly.ServerSdk": "[8.14.1, )"
         }
       },
       "bitwarden.server.sdk.features.analyzers": {

--- a/extensions/Bitwarden.Server.Sdk.Features/tests/Bitwarden.Server.Sdk.Features.CodeFixers.Tests/packages.lock.json
+++ b/extensions/Bitwarden.Server.Sdk.Features/tests/Bitwarden.Server.Sdk.Features.CodeFixers.Tests/packages.lock.json
@@ -116,8 +116,8 @@
       },
       "LaunchDarkly.EventSource": {
         "type": "Transitive",
-        "resolved": "5.3.0",
-        "contentHash": "i++YvdrzvTc1tOxfVreU2yjo/E+iTFcVtwiB4PZ/3uTouNdhABLbJfz1jmGN3jmnvJKWhsMeEZLZM0dzkI+PXQ==",
+        "resolved": "5.3.1",
+        "contentHash": "bVXethnjYnjC+hYSHYhn+1QFZhwtD0NYy1MJjtfOfC6CBW9h1pzR0hEAf16DQYl/LJtMi7fwOJbQhq8lFlFrSw==",
         "dependencies": {
           "LaunchDarkly.Logging": "[2.0.0, 3.0.0)"
         }
@@ -141,12 +141,12 @@
       },
       "LaunchDarkly.ServerSdk": {
         "type": "Transitive",
-        "resolved": "8.12.0",
-        "contentHash": "ZxX2F4pZhHIuskgZqPGv2UoSVcPbwW7vsTZQWcg/tDaS3sw0ykgNhmSlE1rzf1l4Lsz/JBKtfKQLIo6A9tNm7A==",
+        "resolved": "8.14.1",
+        "contentHash": "ufdAP+8OYpLEnDJanErS7wXj9xRYKCY1ZXmxaYuQwTB0qik3DviMRy5ml6Ehjd8kGgWZzOnur5EwqTKM+wW/AQ==",
         "dependencies": {
           "LaunchDarkly.Cache": "1.0.2",
           "LaunchDarkly.CommonSdk": "7.2.0",
-          "LaunchDarkly.EventSource": "5.3.0",
+          "LaunchDarkly.EventSource": "5.3.1",
           "LaunchDarkly.InternalSdk": "3.6.1",
           "LaunchDarkly.Logging": "2.0.0"
         }
@@ -874,7 +874,7 @@
       "bitwarden.server.sdk.features": {
         "type": "Project",
         "dependencies": {
-          "LaunchDarkly.ServerSdk": "[8.12.0, )"
+          "LaunchDarkly.ServerSdk": "[8.14.1, )"
         }
       },
       "bitwarden.server.sdk.features.analyzers": {

--- a/extensions/Bitwarden.Server.Sdk.Features/tests/Bitwarden.Server.Sdk.Features.Tests/packages.lock.json
+++ b/extensions/Bitwarden.Server.Sdk.Features/tests/Bitwarden.Server.Sdk.Features.Tests/packages.lock.json
@@ -65,8 +65,8 @@
       },
       "LaunchDarkly.EventSource": {
         "type": "Transitive",
-        "resolved": "5.3.0",
-        "contentHash": "i++YvdrzvTc1tOxfVreU2yjo/E+iTFcVtwiB4PZ/3uTouNdhABLbJfz1jmGN3jmnvJKWhsMeEZLZM0dzkI+PXQ==",
+        "resolved": "5.3.1",
+        "contentHash": "bVXethnjYnjC+hYSHYhn+1QFZhwtD0NYy1MJjtfOfC6CBW9h1pzR0hEAf16DQYl/LJtMi7fwOJbQhq8lFlFrSw==",
         "dependencies": {
           "LaunchDarkly.Logging": "[2.0.0, 3.0.0)"
         }
@@ -90,12 +90,12 @@
       },
       "LaunchDarkly.ServerSdk": {
         "type": "Transitive",
-        "resolved": "8.12.0",
-        "contentHash": "ZxX2F4pZhHIuskgZqPGv2UoSVcPbwW7vsTZQWcg/tDaS3sw0ykgNhmSlE1rzf1l4Lsz/JBKtfKQLIo6A9tNm7A==",
+        "resolved": "8.14.1",
+        "contentHash": "ufdAP+8OYpLEnDJanErS7wXj9xRYKCY1ZXmxaYuQwTB0qik3DviMRy5ml6Ehjd8kGgWZzOnur5EwqTKM+wW/AQ==",
         "dependencies": {
           "LaunchDarkly.Cache": "1.0.2",
           "LaunchDarkly.CommonSdk": "7.2.0",
-          "LaunchDarkly.EventSource": "5.3.0",
+          "LaunchDarkly.EventSource": "5.3.1",
           "LaunchDarkly.InternalSdk": "3.6.1",
           "LaunchDarkly.Logging": "2.0.0"
         }
@@ -270,7 +270,7 @@
       "bitwarden.server.sdk.features": {
         "type": "Project",
         "dependencies": {
-          "LaunchDarkly.ServerSdk": "[8.12.0, )"
+          "LaunchDarkly.ServerSdk": "[8.14.1, )"
         }
       }
     }

--- a/extensions/Bitwarden.Server.Sdk/tests/Bitwarden.Server.Sdk.IntegrationTests/packages.lock.json
+++ b/extensions/Bitwarden.Server.Sdk/tests/Bitwarden.Server.Sdk.IntegrationTests/packages.lock.json
@@ -124,8 +124,8 @@
       },
       "LaunchDarkly.EventSource": {
         "type": "Transitive",
-        "resolved": "5.3.0",
-        "contentHash": "i++YvdrzvTc1tOxfVreU2yjo/E+iTFcVtwiB4PZ/3uTouNdhABLbJfz1jmGN3jmnvJKWhsMeEZLZM0dzkI+PXQ==",
+        "resolved": "5.3.1",
+        "contentHash": "bVXethnjYnjC+hYSHYhn+1QFZhwtD0NYy1MJjtfOfC6CBW9h1pzR0hEAf16DQYl/LJtMi7fwOJbQhq8lFlFrSw==",
         "dependencies": {
           "LaunchDarkly.Logging": "[2.0.0, 3.0.0)"
         }
@@ -149,12 +149,12 @@
       },
       "LaunchDarkly.ServerSdk": {
         "type": "Transitive",
-        "resolved": "8.12.0",
-        "contentHash": "ZxX2F4pZhHIuskgZqPGv2UoSVcPbwW7vsTZQWcg/tDaS3sw0ykgNhmSlE1rzf1l4Lsz/JBKtfKQLIo6A9tNm7A==",
+        "resolved": "8.14.1",
+        "contentHash": "ufdAP+8OYpLEnDJanErS7wXj9xRYKCY1ZXmxaYuQwTB0qik3DviMRy5ml6Ehjd8kGgWZzOnur5EwqTKM+wW/AQ==",
         "dependencies": {
           "LaunchDarkly.Cache": "1.0.2",
           "LaunchDarkly.CommonSdk": "7.2.0",
-          "LaunchDarkly.EventSource": "5.3.0",
+          "LaunchDarkly.EventSource": "5.3.1",
           "LaunchDarkly.InternalSdk": "3.6.1",
           "LaunchDarkly.Logging": "2.0.0"
         }
@@ -455,7 +455,7 @@
       "bitwarden.server.sdk.features": {
         "type": "Project",
         "dependencies": {
-          "LaunchDarkly.ServerSdk": "[8.12.0, )"
+          "LaunchDarkly.ServerSdk": "[8.14.1, )"
         }
       }
     }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

I pushed `Bitwarden.Server.Sdk.Features@1.2.0` which was the first version that referenced `LaunchDarkly.ServerSdk@8.12.0` and it started failing my `Bitwarden.Server.Sdk` integration tests when I pointed at `1.2.0` because LaunchDarkly had started putting extra files in their nuget package that caused issues when publishing an app that referenced their package. They removed the extra files in 8.14.0 so the issue stopped happening. So I am updating that package so I can push another version of our package and get a new version of the server SDK out.

## 🚨 Breaking Changes

<!-- Does this PR introduce breaking changes for downstream .NET consumers? If yes, document them clearly.

If breaking changes exist:
1. Describe the public API, behavior, or configuration change
2. Explain why the change was necessary
3. Provide concrete migration steps for client developers
4. Link to any related or coordinated PRs/releases

If there are no breaking changes, delete this section. -->
