### PR TITLE
Add [RequireFeature] tests

### DIFF
--- a/extensions/Bitwarden.Server.Sdk.Features/tests/Bitwarden.Server.Sdk.Features.Tests/Bitwarden.Server.Sdk.Features.Tests.csproj
+++ b/extensions/Bitwarden.Server.Sdk.Features/tests/Bitwarden.Server.Sdk.Features.Tests/Bitwarden.Server.Sdk.Features.Tests.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="[18.0.4]" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="[8.0.20]" />
     <PackageReference Include="NSubstitute" Version="[5.3.0]" />

--- a/extensions/Bitwarden.Server.Sdk.Features/tests/Bitwarden.Server.Sdk.Features.Tests/RequireFeatureAttributeTests.cs
+++ b/extensions/Bitwarden.Server.Sdk.Features/tests/Bitwarden.Server.Sdk.Features.Tests/RequireFeatureAttributeTests.cs
@@ -1,0 +1,171 @@
+using System.Net;
+using Bitwarden.Server.Sdk.Features;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Bitwarden.Server.Sdk.UnitTests.Features;
+
+public class RequireFeatureAttributeTests
+{
+    [Fact]
+    public async Task ControllerClass_FeatureDisabled_Returns404()
+    {
+        using var host = CreateHost();
+        await host.StartAsync(TestContext.Current.CancellationToken);
+
+        var response = await host.GetTestClient().GetAsync("/controller-gated", TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ControllerClass_FeatureEnabled_Returns200()
+    {
+        using var host = CreateHost(services =>
+            services.AddFeatureFlagValues([KeyValuePair.Create("controller-feature", "true")]));
+        await host.StartAsync(TestContext.Current.CancellationToken);
+
+        var response = await host.GetTestClient().GetAsync("/controller-gated", TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ControllerAction_FeatureDisabled_Returns404()
+    {
+        using var host = CreateHost();
+        await host.StartAsync(TestContext.Current.CancellationToken);
+
+        var response = await host.GetTestClient().GetAsync("/action-gated", TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ControllerAction_FeatureEnabled_Returns200()
+    {
+        using var host = CreateHost(services =>
+            services.AddFeatureFlagValues([KeyValuePair.Create("action-feature", "true")]));
+        await host.StartAsync(TestContext.Current.CancellationToken);
+
+        var response = await host.GetTestClient().GetAsync("/action-gated", TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ControllerAction_SiblingActionWithoutAttribute_Accessible()
+    {
+        using var host = CreateHost();
+        await host.StartAsync(TestContext.Current.CancellationToken);
+
+        var response = await host.GetTestClient().GetAsync("/ungated", TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task MinimalApiDelegate_FeatureDisabled_Returns404()
+    {
+        using var host = CreateHost();
+        await host.StartAsync(TestContext.Current.CancellationToken);
+
+        var response = await host.GetTestClient().GetAsync("/delegate-gated", TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task MinimalApiDelegate_FeatureEnabled_Returns200()
+    {
+        using var host = CreateHost(services =>
+            services.AddFeatureFlagValues([KeyValuePair.Create("delegate-feature", "true")]));
+        await host.StartAsync(TestContext.Current.CancellationToken);
+
+        var response = await host.GetTestClient().GetAsync("/delegate-gated", TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task AnonymousDelegate_FeatureDisabled_Returns404()
+    {
+        using var host = CreateHost();
+        await host.StartAsync(TestContext.Current.CancellationToken);
+
+        var response = await host.GetTestClient().GetAsync("/lambda-gated", TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task AnonymousDelegate_FeatureEnabled_Returns200()
+    {
+        using var host = CreateHost(services =>
+            services.AddFeatureFlagValues([KeyValuePair.Create("lambda-feature", "true")]));
+        await host.StartAsync(TestContext.Current.CancellationToken);
+
+        var response = await host.GetTestClient().GetAsync("/lambda-gated", TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [RequireFeature("delegate-feature")]
+    private static Ok DelegateHandler() => TypedResults.Ok();
+
+    private static IHost CreateHost(Action<IServiceCollection>? configureServices = null)
+    {
+        return new HostBuilder()
+            .UseEnvironment("Development")
+            .ConfigureWebHost(webHostBuilder =>
+            {
+                webHostBuilder
+                    .UseTestServer()
+                    .ConfigureServices((_, services) =>
+                    {
+                        services.AddRouting();
+                        services.AddControllers()
+                            .AddApplicationPart(typeof(RequireFeatureAttributeTests).Assembly);
+                        services.AddFeatureFlagServices();
+                        configureServices?.Invoke(services);
+                    })
+                    .Configure(app =>
+                    {
+                        app.UseRouting();
+                        app.UseFeatureFlagChecks();
+                        app.UseEndpoints(endpoints =>
+                        {
+                            endpoints.MapControllers();
+                            endpoints.MapGet("/delegate-gated", DelegateHandler);
+                            endpoints.MapGet("/lambda-gated", [RequireFeature("lambda-feature")] () => TypedResults.Ok());
+                        });
+                    });
+            })
+            .Build();
+    }
+}
+
+[RequireFeature("controller-feature")]
+[Route("/controller-gated")]
+public class FeatureGatedController : ControllerBase
+{
+    [HttpGet]
+    public IActionResult Get() => Ok();
+}
+
+[Route("")]
+public class MixedController : ControllerBase
+{
+    [RequireFeature("action-feature")]
+    [HttpGet("/action-gated")]
+    public IActionResult GatedAction() => Ok();
+
+    [HttpGet("/ungated")]
+    public IActionResult UngatedAction() => Ok();
+}


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

I was asked if the sdk `[RequireFeature]` attribute was able to be placed on controller actions and I definitely intended for it to work that way since it works metadata based which all attributes on controller actions should be (just like `[Authorize]`) but I did not have any tests that actually validated that. I added those tests and everything does work as expected, even using it as an attribute on the anonymous lambda of a minimal API endpoint even though I would still recommend using the `.RequireFeature("Key");` syntax which already has tests.

## 🚨 Breaking Changes

<!-- Does this PR introduce breaking changes for downstream .NET consumers? If yes, document them clearly.

If breaking changes exist:
1. Describe the public API, behavior, or configuration change
2. Explain why the change was necessary
3. Provide concrete migration steps for client developers
4. Link to any related or coordinated PRs/releases

If there are no breaking changes, delete this section. -->
