### PR TITLE
Default Telemetry, Authentication, and WebEssentials to Exe-only

### DIFF
--- a/extensions/Bitwarden.Server.Sdk/src/PACKAGE.md
+++ b/extensions/Bitwarden.Server.Sdk/src/PACKAGE.md
@@ -12,8 +12,9 @@ right underneath the top level `<Project>` element in your `.csproj` file.
 
 ## Telemetry
 
-Enabled by default and able to be removed using `<BitIncludeTelemetry>false</BitIncludeTelemetry>`
-in your project file.
+Enabled by default for executable projects (`OutputType=Exe`) and disabled by default otherwise.
+Can be overridden using `<BitIncludeTelemetry>true</BitIncludeTelemetry>` or
+`<BitIncludeTelemetry>false</BitIncludeTelemetry>` in your project file.
 
 This feature automatically includes a suite of OpenTelemetry libraries and registers those services
 into the `IServiceCollection`.
@@ -29,7 +30,8 @@ of that package apply to this SDK.
 
 ## Authentication
 
-Enabled by default and able to be removed using
+Enabled by default for executable projects (`OutputType=Exe`) and disabled by default otherwise.
+Can be overridden using `<BitIncludeAuthentication>true</BitIncludeAuthentication>` or
 `<BitIncludeAuthentication>false</BitIncludeAuthentication>` in your project file.
 
 This feature automatically includes the `Bitwarden.Server.Sdk.Authentication` library and when using
@@ -38,8 +40,9 @@ the `Microsoft.NET.Sdk.Web` SDK it will register Bitwarden style authentication 
 
 ## Web Essentials
 
-Enabled by default and able to be removed using `<BitIncludeWebEssentials>false</BitIncludeWebEssentials>`
-in your project file.
+Enabled by default for executable projects (`OutputType=Exe`) and disabled by default otherwise.
+Can be overridden using `<BitIncludeWebEssentials>true</BitIncludeWebEssentials>` or
+`<BitIncludeWebEssentials>false</BitIncludeWebEssentials>` in your project file.
 
 This feature automatically includes the `Bitwarden.Server.Sdk.WebEssentials` library and registers
 its services in `UseBitwardenSdk()`. All considerations of that package apply to this SDK.

--- a/extensions/Bitwarden.Server.Sdk/src/README.md
+++ b/extensions/Bitwarden.Server.Sdk/src/README.md
@@ -15,7 +15,9 @@ decisions be known to us in the props file. This is why all we do is declare a m
 
 The [./Sdk/Sdk.targets](./Sdk/Sdk.targets) file is expected to be imported last. This way,
 properties defined in a consumer project will have been evaluated and can be used to make decisions
-on which packages to automatically reference.
+on which packages to automatically reference. Several features default to enabled only when
+`OutputType=Exe`. `Microsoft.NET.Sdk.Web` sets `OutputType=Exe` by default, so standard web
+application projects get these features automatically.
 
 The [`Content`](./Content/) directory are additional files that are packaged into the resulting
 NuGet package in their plaintext form. The `Sdk.targets` file can use files from here and include

--- a/extensions/Bitwarden.Server.Sdk/src/Sdk/Sdk.targets
+++ b/extensions/Bitwarden.Server.Sdk/src/Sdk/Sdk.targets
@@ -22,20 +22,23 @@
 
   <!-- TODO Use the constants in places to avoid any configuration that doesn't compile -->
   <PropertyGroup Label="Define feature defaults and constants">
-    <!-- Telemetry defaults to on -->
-    <BitIncludeTelemetry Condition="'$(BitIncludeTelemetry)' == ''">true</BitIncludeTelemetry>
+    <!-- Telemetry defaults to on for executables, off otherwise -->
+    <BitIncludeTelemetry Condition="'$(BitIncludeTelemetry)' == '' and '$(OutputType)' == 'Exe'">true</BitIncludeTelemetry>
+    <BitIncludeTelemetry Condition="'$(BitIncludeTelemetry)' == ''">false</BitIncludeTelemetry>
     <DefineConstants Condition="'$(BitIncludeTelemetry)' == 'true'">$(DefineConstants);BIT_INCLUDE_TELEMETRY</DefineConstants>
     <!-- Features defaults to on -->
     <BitIncludeFeatures Condition="'$(BitIncludeFeatures)' == ''">true</BitIncludeFeatures>
     <DefineConstants Condition="'$(BitIncludeFeatures)' == 'true'">$(DefineConstants);BIT_INCLUDE_FEATURES</DefineConstants>
-    <!-- Authentication defaults to on -->
-    <BitIncludeAuthentication Condition="'$(BitIncludeAuthentication)' == ''">true</BitIncludeAuthentication>
+    <!-- Authentication defaults to on for executables, off otherwise -->
+    <BitIncludeAuthentication Condition="'$(BitIncludeAuthentication)' == '' and '$(OutputType)' == 'Exe'">true</BitIncludeAuthentication>
+    <BitIncludeAuthentication Condition="'$(BitIncludeAuthentication)' == ''">false</BitIncludeAuthentication>
     <DefineConstants Condition="'$(BitIncludeAuthentication)' == 'true'">$(DefineConstants);BIT_INCLUDE_AUTHENTICATION</DefineConstants>
     <!-- Caching defaults to off -->
     <BitIncludeCaching Condition="'$(BitIncludeCaching)' == ''">false</BitIncludeCaching>
     <DefineConstants Condition="'$(BitIncludeCaching)' == 'true'">$(DefineConstants);BIT_INCLUDE_CACHING</DefineConstants>
-    <!-- WebEssentials defaults to on -->
-    <BitIncludeWebEssentials Condition="'$(BitIncludeWebEssentials)' == ''">true</BitIncludeWebEssentials>
+    <!-- WebEssentials defaults to on for executables, off otherwise -->
+    <BitIncludeWebEssentials Condition="'$(BitIncludeWebEssentials)' == '' and '$(OutputType)' == 'Exe'">true</BitIncludeWebEssentials>
+    <BitIncludeWebEssentials Condition="'$(BitIncludeWebEssentials)' == ''">false</BitIncludeWebEssentials>
     <DefineConstants Condition="'$(BitIncludeWebEssentials)' == 'true'">$(DefineConstants);BIT_INCLUDE_WEB_ESSENTIALS</DefineConstants>
 
     <!--

--- a/extensions/Bitwarden.Server.Sdk/tests/Bitwarden.Server.Sdk.IntegrationTests/SdkTests.cs
+++ b/extensions/Bitwarden.Server.Sdk/tests/Bitwarden.Server.Sdk.IntegrationTests/SdkTests.cs
@@ -29,6 +29,21 @@ public class SdkTests : MSBuildTestBase
     }
 
     [Fact]
+    public void LibraryProject_DefaultsEntryPointFeaturesOff()
+    {
+        var project = ProjectCreator.Templates.SdkProject(sdk: "Microsoft.NET.Sdk");
+
+        foreach (var feature in new[] { "TELEMETRY", "AUTHENTICATION", "WEB_ESSENTIALS" })
+        {
+            project.TryGetConstant($"BIT_INCLUDE_{feature}", out var actual);
+            Assert.False(actual);
+        }
+
+        project.TryGetConstant("BIT_INCLUDE_FEATURES", out var features);
+        Assert.True(features);
+    }
+
+    [Fact]
     public void ShouldBuildWithNoWarningsIfProjectHasNullableDisabled()
     {
         ProjectCreator.Templates.SdkProject(


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

`BitIncludeTelemetry`, `BitIncludeAuthentication`, and `BitIncludeWebEssentials` now default to
`true` only when `OutputType=Exe`, and `false` otherwise. These features are entry-point concerns
and should not be pulled in by default for library projects.

Projects using `Microsoft.NET.Sdk.Web` have `OutputType=Exe` by default, so they continue to get
these features automatically with no changes required.

## 🚨 Breaking Changes

Library projects (non-`Exe`) that previously relied on these features being enabled by default will
need to opt in explicitly:

```xml
<BitIncludeTelemetry>true</BitIncludeTelemetry>
<BitIncludeAuthentication>true</BitIncludeAuthentication>
<BitIncludeWebEssentials>true</BitIncludeWebEssentials>
```