### PR TITLE
Add Bitwarden.Server.Sdk.Environment to the Server SDK

### DIFF
--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -99,3 +99,38 @@ services.TryAddTransient<IThirdService, ThirdService>();
 ```
 
 The code fix handles both generic and non-generic overloads, as well as all `AddKeyed*` variants (`TryAddKeyedSingleton`, `TryAddKeyedScoped`, `TryAddKeyedTransient`).
+
+---
+
+## BW0004
+
+**Title:** BitIncludeEnvironment is incompatible with dependent packages
+**Severity:** Warning
+**Category:** Configuration
+**Package:** `Bitwarden.Server.Sdk`
+**Code fix available:** No
+
+### Summary
+
+Reported when `BitIncludeEnvironment` is set to `false` while `BitIncludeFeatures` or `BitIncludeWebEssentials` is set to `true`. Both of those packages depend on `Bitwarden.Server.Sdk.Environment`, so `IBitwardenEnvironment` will still be available transitively even though `BitIncludeEnvironment` is `false`. Additionally, `AddBitwardenEnvironment()` will not be called by `UseBitwardenSdk()` in this configuration.
+
+### Example
+
+```xml
+<!-- BW0004 is reported for this combination -->
+<BitIncludeEnvironment>false</BitIncludeEnvironment>
+<BitIncludeFeatures>true</BitIncludeFeatures>
+```
+
+**Fix:** Either set `BitIncludeEnvironment` to `true`, or disable the dependent packages:
+
+```xml
+<BitIncludeEnvironment>true</BitIncludeEnvironment>
+<BitIncludeFeatures>true</BitIncludeFeatures>
+```
+
+To suppress the warning if the behavior is intentional:
+
+```xml
+<NoWarn>$(NoWarn);BW0004</NoWarn>
+```

--- a/extensions/Bitwarden.Server.Sdk/src/Content/HostBuilderExtensions.cs
+++ b/extensions/Bitwarden.Server.Sdk/src/Content/HostBuilderExtensions.cs
@@ -58,6 +58,10 @@ public static class HostBuilderExtensions
         builder.Services.AddWebEssentials();
 #endif
 
+#if BIT_INCLUDE_ENVIRONMENT
+        builder.Services.AddBitwardenEnvironment();
+#endif
+
 #if BIT_INCLUDE_ASPIRE_INTEGRATION
         builder.Services.AddServiceDiscovery();
 
@@ -117,6 +121,13 @@ public static class HostBuilderExtensions
         hostBuilder.ConfigureServices((_, services) =>
         {
             services.AddWebEssentials();
+        });
+#endif
+
+#if BIT_INCLUDE_ENVIRONMENT
+        hostBuilder.ConfigureServices((_, services) =>
+        {
+            services.AddBitwardenEnvironment();
         });
 #endif
 

--- a/extensions/Bitwarden.Server.Sdk/src/PACKAGE.md
+++ b/extensions/Bitwarden.Server.Sdk/src/PACKAGE.md
@@ -53,6 +53,35 @@ To add the security headers middleware, call `UseSecurityHeaders()` on your appl
 app.UseSecurityHeaders();
 ```
 
+## Environment
+
+Enabled by default for all project types. Can be disabled using
+`<BitIncludeEnvironment>false</BitIncludeEnvironment>` in your project file.
+
+This feature automatically includes the `Bitwarden.Server.Sdk.Environment` library and registers
+`IBitwardenEnvironment` in `UseBitwardenSdk()`. `IBitwardenEnvironment` exposes the application
+version, Git hash, and self-host details.
+
+Note that `Bitwarden.Server.Sdk.Features` and `Bitwarden.Server.Sdk.WebEssentials` both depend on
+this package internally, so disabling `BitIncludeEnvironment` while either of those is enabled will
+produce a build warning.
+
+If your service can run in a self-hosted configuration, configure `SelfHostDetails` after calling
+`UseBitwardenSdk()`:
+
+```csharp
+using Bitwarden.Server.Sdk.Environment.Setup;
+
+builder.Services.AddOptions<SelfHostDetails>()
+    .Configure<IConfiguration>((details, config) =>
+    {
+        if (config.GetValue<bool>("globalSettings:selfHosted"))
+            details.MakeSelfHost(config["globalSettings:selfHostFlavor"] ?? "unknown");
+        else
+            details.MakeCloud();
+    });
+```
+
 ## Aspire Integration
 
 Disabled by default and able to be enabled using `<BitAspireIntegration>enabled</BitAspireIntegration>`

--- a/extensions/Bitwarden.Server.Sdk/src/Sdk/Sdk.targets
+++ b/extensions/Bitwarden.Server.Sdk/src/Sdk/Sdk.targets
@@ -94,6 +94,7 @@
 
   <Target Name="CheckBitwardenEnvironmentCompatibility" BeforeTargets="Build">
     <Warning
+      Code="BW0004"
       Condition="'$(BitIncludeEnvironment)' == 'false' and ('$(BitIncludeFeatures)' == 'true' or '$(BitIncludeWebEssentials)' == 'true')"
       Text="BitIncludeEnvironment is false but BitIncludeFeatures or BitIncludeWebEssentials is true. Those packages depend on Bitwarden.Server.Sdk.Environment, so the type will still be available transitively and AddBitwardenEnvironment() will not be called by UseBitwardenSdk(). Set BitIncludeEnvironment to true or disable the dependent packages." />
   </Target>

--- a/extensions/Bitwarden.Server.Sdk/src/Sdk/Sdk.targets
+++ b/extensions/Bitwarden.Server.Sdk/src/Sdk/Sdk.targets
@@ -40,6 +40,9 @@
     <BitIncludeWebEssentials Condition="'$(BitIncludeWebEssentials)' == '' and '$(OutputType)' == 'Exe'">true</BitIncludeWebEssentials>
     <BitIncludeWebEssentials Condition="'$(BitIncludeWebEssentials)' == ''">false</BitIncludeWebEssentials>
     <DefineConstants Condition="'$(BitIncludeWebEssentials)' == 'true'">$(DefineConstants);BIT_INCLUDE_WEB_ESSENTIALS</DefineConstants>
+    <!-- Environment defaults to on -->
+    <BitIncludeEnvironment Condition="'$(BitIncludeEnvironment)' == ''">true</BitIncludeEnvironment>
+    <DefineConstants Condition="'$(BitIncludeEnvironment)' == 'true'">$(DefineConstants);BIT_INCLUDE_ENVIRONMENT</DefineConstants>
 
     <!--
       Aspire integration defaults to disabled
@@ -66,7 +69,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(BitIncludeFeatures)' == 'true'">
-    <PackageReference Include="Bitwarden.Server.Sdk.Features" Version="1.3.0" />
+    <PackageReference Include="Bitwarden.Server.Sdk.Features" Version="1.4.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(BitIncludeAuthentication)' == 'true'">
@@ -78,10 +81,20 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(BitIncludeWebEssentials)' == 'true'">
-    <PackageReference Include="Bitwarden.Server.Sdk.WebEssentials" Version="0.4.0" />
+    <PackageReference Include="Bitwarden.Server.Sdk.WebEssentials" Version="0.5.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(BitIncludeEnvironment)' == 'true'">
+    <PackageReference Include="Bitwarden.Server.Sdk.Environment" Version="0.1.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(BitAspireIntegration)' == 'enabled'">
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.4.0" />
   </ItemGroup>
+
+  <Target Name="CheckBitwardenEnvironmentCompatibility" BeforeTargets="Build">
+    <Warning
+      Condition="'$(BitIncludeEnvironment)' == 'false' and ('$(BitIncludeFeatures)' == 'true' or '$(BitIncludeWebEssentials)' == 'true')"
+      Text="BitIncludeEnvironment is false but BitIncludeFeatures or BitIncludeWebEssentials is true. Those packages depend on Bitwarden.Server.Sdk.Environment, so the type will still be available transitively and AddBitwardenEnvironment() will not be called by UseBitwardenSdk(). Set BitIncludeEnvironment to true or disable the dependent packages." />
+  </Target>
 </Project>

--- a/extensions/Bitwarden.Server.Sdk/tests/Bitwarden.Server.Sdk.IntegrationTests/Bitwarden.Server.Sdk.IntegrationTests.csproj
+++ b/extensions/Bitwarden.Server.Sdk/tests/Bitwarden.Server.Sdk.IntegrationTests/Bitwarden.Server.Sdk.IntegrationTests.csproj
@@ -38,6 +38,7 @@
   <ItemGroup>
     <SdkPackage Include="Features" />
     <SdkPackage Include="Authentication" />
+    <SdkPackage Include="Environment" />
 
     <!-- Create a project reference for each Sdk package -->
     <ProjectReference Include="@(SdkPackage->'..\..\..\Bitwarden.Server.Sdk.%(Identity)\src\Bitwarden.Server.Sdk.%(Identity).csproj')" />

--- a/extensions/Bitwarden.Server.Sdk/tests/Bitwarden.Server.Sdk.IntegrationTests/CustomProjectCreatorTemplates.cs
+++ b/extensions/Bitwarden.Server.Sdk/tests/Bitwarden.Server.Sdk.IntegrationTests/CustomProjectCreatorTemplates.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using Bitwarden.Server.Sdk.Environment;
 using Bitwarden.Server.Sdk.Features;
 using Microsoft.Build.Utilities.ProjectCreation;
 using Microsoft.Extensions.DependencyInjection;
@@ -20,7 +21,7 @@ public static class CustomProjectCreatorTemplates
         var extensionsRoot = new DirectoryInfo(Path.Combine(ThisAssemblyDirectory, "..", "..", "..", "..", "..", ".."));
         Debug.WriteLine($"ExtensionsRoot: {extensionsRoot.FullName}");
 
-        Type[] markerTypes = [typeof(IFeatureService), typeof(BitwardenAuthenticationServiceCollectionExtensions)];
+        Type[] markerTypes = [typeof(IFeatureService), typeof(BitwardenAuthenticationServiceCollectionExtensions), typeof(IBitwardenEnvironment)];
         var nugetPackages = new FileInfo[markerTypes.Length];
 
         for (var i = 0; i < nugetPackages.Length; i++)

--- a/extensions/Bitwarden.Server.Sdk/tests/Bitwarden.Server.Sdk.IntegrationTests/SdkTests.cs
+++ b/extensions/Bitwarden.Server.Sdk/tests/Bitwarden.Server.Sdk.IntegrationTests/SdkTests.cs
@@ -15,6 +15,7 @@ public class SdkTests : MSBuildTestBase
             ("AUTHENTICATION", true),
             ("CACHING", false),
             ("WEB_ESSENTIALS", true),
+            ("ENVIRONMENT", true),
         ];
 
         var project = ProjectCreator.Templates.SdkProject(out var result, out var buildOutput);
@@ -41,6 +42,9 @@ public class SdkTests : MSBuildTestBase
 
         project.TryGetConstant("BIT_INCLUDE_FEATURES", out var features);
         Assert.True(features);
+
+        project.TryGetConstant("BIT_INCLUDE_ENVIRONMENT", out var environment);
+        Assert.True(environment);
     }
 
     [Fact]
@@ -179,6 +183,83 @@ public class SdkTests : MSBuildTestBase
         Assert.True(result, buildOutput.GetConsoleLog());
     }
 
+    [Fact]
+    public void EnvironmentTurnedOff_CanCompile()
+    {
+        ProjectCreator.Templates.SdkProject(
+            out var result,
+            out var buildOutput,
+            customAction: (project) =>
+            {
+                project.Property("BitIncludeEnvironment", bool.FalseString);
+            }
+        );
+
+        Assert.True(result, buildOutput.GetConsoleLog());
+    }
+
+    [Fact]
+    public void EnvironmentTurnedOff_CanNotUseIBitwardenEnvironment()
+    {
+        // Features and WebEssentials both transitively depend on Bitwarden.Server.Sdk.Environment,
+        // so all three must be disabled to truly remove the type from the compilation.
+        ProjectCreator.Templates.SdkProject(
+            out var result,
+            out var buildOutput,
+            customAction: (project) =>
+            {
+                project.Property("BitIncludeEnvironment", bool.FalseString);
+                project.Property("BitIncludeFeatures", bool.FalseString);
+                project.Property("BitIncludeWebEssentials", bool.FalseString);
+            },
+            additional: """
+                app.MapGet("/test", (Bitwarden.Server.Sdk.Environment.IBitwardenEnvironment env) => env.Version);
+                """
+        );
+
+        Assert.False(result, buildOutput.GetConsoleLog());
+
+        // error CS0234: The type or namespace name 'Environment' does not exist in the namespace 'Bitwarden.Server.Sdk' (are you missing an assembly reference?)
+        Assert.Contains(buildOutput.ErrorEvents, e => e.Code == "CS0234");
+    }
+
+    [Theory]
+    [InlineData("BitIncludeFeatures")]
+    [InlineData("BitIncludeWebEssentials")]
+    public void EnvironmentTurnedOff_WithDependentPackageOn_WarnsAboutIncompatibility(string dependentPackage)
+    {
+        ProjectCreator.Templates.SdkProject(
+            out var result,
+            out var buildOutput,
+            customAction: (project) =>
+            {
+                project.Property("BitIncludeEnvironment", bool.FalseString);
+                project.Property(dependentPackage, bool.TrueString);
+            }
+        );
+
+        Assert.True(result, buildOutput.GetConsoleLog());
+        Assert.Contains(buildOutput.WarningEvents, w => w.Message?.Contains("BitIncludeEnvironment") == true);
+    }
+
+    [Fact]
+    public void EnvironmentTurnedOn_CanUseIBitwardenEnvironment()
+    {
+        ProjectCreator.Templates.SdkProject(
+            out var result,
+            out var buildOutput,
+            customAction: (project) =>
+            {
+                project.Property("BitIncludeEnvironment", bool.TrueString);
+            },
+            additional: """
+                app.MapGet("/test", (Bitwarden.Server.Sdk.Environment.IBitwardenEnvironment env) => env.Version);
+                """
+        );
+
+        Assert.True(result, buildOutput.GetConsoleLog());
+    }
+
     public static TheoryData<string> PossibleVariantData()
     {
         var variations = new Dictionary<string, string[]>
@@ -189,6 +270,7 @@ public class SdkTests : MSBuildTestBase
             { "BitIncludeCaching", ["true", "false"] },
             { "BitAspireIntegration", ["enabled", "disabled"] },
             { "BitIncludeWebEssentials", ["true", "false"] },
+            { "BitIncludeEnvironment", ["true", "false"] },
         };
 
         var keys = variations.Keys.ToArray();

--- a/extensions/Bitwarden.Server.Sdk/tests/Bitwarden.Server.Sdk.IntegrationTests/SdkTests.cs
+++ b/extensions/Bitwarden.Server.Sdk/tests/Bitwarden.Server.Sdk.IntegrationTests/SdkTests.cs
@@ -239,7 +239,8 @@ public class SdkTests : MSBuildTestBase
         );
 
         Assert.True(result, buildOutput.GetConsoleLog());
-        Assert.Contains(buildOutput.WarningEvents, w => w.Message?.Contains("BitIncludeEnvironment") == true);
+        var warning = Assert.Single(buildOutput.WarningEvents, w => w.Code == "BW0004");
+        Assert.Contains("BitIncludeEnvironment", warning.Message);
     }
 
     [Fact]

--- a/extensions/Bitwarden.Server.Sdk/tests/Bitwarden.Server.Sdk.IntegrationTests/packages.lock.json
+++ b/extensions/Bitwarden.Server.Sdk/tests/Bitwarden.Server.Sdk.IntegrationTests/packages.lock.json
@@ -205,18 +205,69 @@
         "resolved": "2.2.3",
         "contentHash": "bhwzJfzyiJM0nXJyNB7Y9OfsEXyxLdDBHG99soIp5JjnPydwkOaBdRCtRtWgQh3noSLi2cSIZ/wpbHNNE9knxQ=="
       },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "qGhRPd3VxfLV9UqatVOiD9mAeUbj2KiMwGFYC5uXlzExiZQoe4X/hdmzGIU7BQjNLTqCnnbTHVyBglG3668/HA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "Transitive",
-        "resolved": "8.0.2",
-        "contentHash": "3iE7UF7MQkCv1cxzCahz+Y/guQbTqieyxyaWKhrRO91itI9cOKO76OHeQDahqG4MmW5umr3CcCvGmK92lWNlbg=="
+        "resolved": "10.0.9",
+        "contentHash": "g41l/30G3K4B/d/L8kjux0+30e27c8D0FVQ/PFCpbekgfDpj9mnDhieP67EqXWvl1EWNeZh2rpR4F5B/jcDOHA=="
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "86RgyFsmVslW4Nu28IXgt8tLglynGQrwjk/xhGZaTe8j6YIeR1Ywoc42hSHsBSl920CQdfqq2dBohZiGm3AkUA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "Oxn4vqDk+EwceTMpZxVm7L/UZEAM1qIQlNP1+7tBZckD+P4SKrm/5X4gMTPCTdpnau/xY8Sb4/0d6onomSg4ZA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "Xd/2F+uWblTiUp+ssaDZN2ea4vmnHmW6PXugmqBHumyhqVkyeh6RJ3S2Zo/F+1bXIL/KuGqe2pKv6UiGOc1KeQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.9",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9"
+        }
       },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "Transitive",
-        "resolved": "8.0.3",
-        "contentHash": "dL0QGToTxggRLMYY4ZYX5AMwBb+byQBd/5dMiZE07Nv73o6I5Are3C7eQTh7K2+A4ct0PVISSr7TZANbiNb2yQ==",
+        "resolved": "10.0.9",
+        "contentHash": "9S/DFt4cohlMPpzIxjG6kk0L8MuN2vDm9pbMCulxtJzzk82oJHVLBd8vuQxaPskaYQwKqmFmbannf5eoChgjYg==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9"
         }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "hyNdX4c2UwkRkzb9byw0H2DQkRzwBM3mzY2sCM9egwzTyg8dvQJmp5noQHGEaaCORQrNK3DD2gREBsc2DlXS4A==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "fmEbAUFsaIKirgLt/lYhuFRBwhcSJN31jjHgCdbQxJiWOum6EdLjkbgGuukSP9z/a+9LibaxII/kF+GwOXgC4g=="
       },
       "Microsoft.IdentityModel.Abstractions": {
         "type": "Transitive",
@@ -417,6 +468,15 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.AspNetCore.Authentication.JwtBearer": "[8.0.20, )"
+        }
+      },
+      "bitwarden.server.sdk.environment": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.9, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.0.9, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.0.9, )",
+          "Microsoft.Extensions.Options": "[10.0.9, )"
         }
       },
       "bitwarden.server.sdk.features": {


### PR DESCRIPTION
## Summary

- Adds `Bitwarden.Server.Sdk.Environment` as a new feature in `Sdk.targets`, enabled by default for all project types via `BitIncludeEnvironment`
- Calls `AddBitwardenEnvironment()` in both `IHostApplicationBuilder` and `IHostBuilder` overloads of `UseBitwardenSdk()`
- Adds a `CheckBitwardenEnvironmentCompatibility` MSBuild warning when `BitIncludeEnvironment=false` but `BitIncludeFeatures` or `BitIncludeWebEssentials` is enabled (those packages transitively depend on Environment)
- Adds an **Environment** section to `PACKAGE.md` documenting the default behaviour, opt-out, and `SelfHostDetails` configuration
- Adds integration tests: default value assertion, compile tests, usage tests, and incompatibility warning tests; `BitIncludeEnvironment` added to the all-variants matrix