### PR TITLE
Add ListDeploymentFiles MSBuild target

### DIFF
--- a/extensions/Bitwarden.Server.Sdk/src/PACKAGE.md
+++ b/extensions/Bitwarden.Server.Sdk/src/PACKAGE.md
@@ -53,6 +53,95 @@ To add the security headers middleware, call `UseSecurityHeaders()` on your appl
 app.UseSecurityHeaders();
 ```
 
+## Deployment Files
+
+The SDK provides two MSBuild targets for producing a list of every file whose change should
+trigger a new deployment of the project — its source files, resources, content, referenced
+project files, and NuGet lock file. This list is useful in CI to decide whether a PR actually
+needs a release.
+
+### Targets
+
+**`ListDeploymentFiles`** prints one absolute path per line to the MSBuild console:
+
+```
+dotnet msbuild -t:ListDeploymentFiles -v:m
+```
+
+**`WriteDeploymentFiles`** writes the same list to disk so CI scripts can consume it without
+parsing build output. The default output path is `obj/deployment-files.txt` and can be
+overridden:
+
+```
+dotnet msbuild -t:WriteDeploymentFiles
+dotnet msbuild -t:WriteDeploymentFiles -p:DeploymentFilesOutputPath=deployment-files.txt
+```
+
+### What is included
+
+The following are included automatically:
+
+- The `.csproj` file of each project
+- All `@(Compile)` items (`.cs` source files)
+- All `@(EmbeddedResource)` items
+- All `@(Content)` items where `CopyToOutputDirectory` is not `Never`
+- `packages.lock.json` when `RestorePackagesWithLockFile` is `true`
+- All of the above from transitively referenced projects
+
+To manually include additional files — such as SQL migration scripts, Dockerfiles, or
+configuration templates — add them to the `BitDeploymentInput` item group:
+
+```xml
+<ItemGroup>
+  <BitDeploymentInput Include="Dockerfile" />
+  <BitDeploymentInput Include="migrations/**/*.sql" />
+</ItemGroup>
+```
+
+### CI usage
+
+The following GitHub Actions job uses `WriteDeploymentFiles` to gate a release on whether
+any deployment-relevant file was changed in the PR:
+
+```yaml
+jobs:
+  check-deployment:
+    runs-on: ubuntu-latest
+    outputs:
+      needs-release: ${{ steps.check.outputs.needs-release }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-dotnet@v4
+
+      - name: Write deployment files
+        run: |
+          dotnet msbuild src/MyService/MyService.csproj \
+            -t:WriteDeploymentFiles \
+            -p:DeploymentFilesOutputPath=deployment-files.txt \
+            --nologo -v:q
+
+      - name: Check for overlap with PR changes
+        id: check
+        run: |
+          git diff --name-only origin/${{ github.base_ref }}...HEAD \
+            | sed "s|^|$GITHUB_WORKSPACE/|" \
+            > changed-files.txt
+
+          if grep -qxFf deployment-files.txt changed-files.txt; then
+            echo "needs-release=true" >> $GITHUB_OUTPUT
+          else
+            echo "needs-release=false" >> $GITHUB_OUTPUT
+          fi
+```
+
+The `sed` step converts `git diff`'s repo-relative paths to absolute paths so they can be
+compared against the absolute paths written by `WriteDeploymentFiles`. `grep -xFf` does
+exact whole-line fixed-string matching, so partial path matches cannot produce false
+positives.
+
 ## Aspire Integration
 
 Disabled by default and able to be enabled using `<BitAspireIntegration>enabled</BitAspireIntegration>`

--- a/extensions/Bitwarden.Server.Sdk/src/Sdk/Sdk.targets
+++ b/extensions/Bitwarden.Server.Sdk/src/Sdk/Sdk.targets
@@ -84,4 +84,77 @@
   <ItemGroup Condition="'$(BitAspireIntegration)' == 'enabled'">
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.4.0" />
   </ItemGroup>
+
+  <!-- Internal target that recursively collects deployment files from this project and all
+       transitively referenced projects. Used by ListDeploymentFiles. -->
+  <Target Name="_CollectDeploymentFiles" Returns="@(_DeploymentFile)">
+    <MSBuild
+      Projects="@(ProjectReference)"
+      Targets="_CollectDeploymentFiles"
+      SkipNonexistentTargets="true">
+      <Output TaskParameter="TargetOutputs" ItemName="_DeploymentFile" />
+    </MSBuild>
+    <PropertyGroup>
+      <!-- NuGetLockFilePath is only populated from restore-generated props, so default it
+           here to the same path NuGet would use if it hasn't been resolved yet. -->
+      <_LockFilePath Condition="'$(NuGetLockFilePath)' != ''">$(NuGetLockFilePath)</_LockFilePath>
+      <_LockFilePath Condition="'$(_LockFilePath)' == ''">$([MSBuild]::NormalizePath($(MSBuildProjectDirectory), 'packages.lock.json'))</_LockFilePath>
+    </PropertyGroup>
+    <ItemGroup>
+      <_DeploymentFile Include="$(MSBuildProjectFullPath)" />
+      <_DeploymentFile Include="@(Compile->'%(FullPath)')" />
+      <_DeploymentFile Include="@(EmbeddedResource->'%(FullPath)')" />
+      <_DeploymentFile Include="%(Content.FullPath)" Condition="'%(Content.CopyToOutputDirectory)' != 'Never'" />
+      <_DeploymentFile Include="@(BitDeploymentInput->'%(FullPath)')" />
+      <_DeploymentFile Include="$(_LockFilePath)" Condition="'$(RestorePackagesWithLockFile)' == 'true' AND Exists('$(_LockFilePath)')" />
+    </ItemGroup>
+  </Target>
+
+  <!--
+    Lists every file that contributes to the deployment of the consuming project,
+    including all transitively referenced projects. Duplicates (e.g. from diamond
+    dependencies) are removed.
+
+    To manually include additional files (e.g. config files, SQL scripts) that should
+    influence deployment decisions, add them to the BitDeploymentInput item group:
+
+      <ItemGroup>
+        <BitDeploymentInput Include="appsettings.json" />
+      </ItemGroup>
+
+    Usage: dotnet msbuild -t:ListDeploymentFiles
+  -->
+  <Target Name="ListDeploymentFiles" DependsOnTargets="_CollectDeploymentFiles">
+    <RemoveDuplicates Inputs="@(_DeploymentFile)">
+      <Output TaskParameter="Filtered" ItemName="_UniqueDeploymentFile" />
+    </RemoveDuplicates>
+    <Message Importance="High" Text="%(_UniqueDeploymentFile.Identity)" />
+  </Target>
+
+  <!--
+    Writes the deployment file list to disk (one absolute path per line) for
+    consumption by CI scripts without parsing MSBuild console output.
+
+    The output path defaults to $(BaseIntermediateOutputPath)deployment-files.txt
+    and can be overridden via a property:
+
+      dotnet msbuild -t:WriteDeploymentFiles -p:DeploymentFilesOutputPath=out.txt
+
+    Usage: dotnet msbuild -t:WriteDeploymentFiles
+  -->
+  <PropertyGroup>
+    <DeploymentFilesOutputPath Condition="'$(DeploymentFilesOutputPath)' == ''">$(BaseIntermediateOutputPath)deployment-files.txt</DeploymentFilesOutputPath>
+  </PropertyGroup>
+
+  <Target Name="WriteDeploymentFiles" DependsOnTargets="_CollectDeploymentFiles">
+    <RemoveDuplicates Inputs="@(_DeploymentFile)">
+      <Output TaskParameter="Filtered" ItemName="_UniqueDeploymentFile" />
+    </RemoveDuplicates>
+    <WriteLinesToFile
+      File="$(DeploymentFilesOutputPath)"
+      Lines="@(_UniqueDeploymentFile)"
+      Overwrite="true"
+      WriteOnlyWhenDifferent="true" />
+    <Message Importance="High" Text="Deployment files written to: $(DeploymentFilesOutputPath)" />
+  </Target>
 </Project>

--- a/extensions/Bitwarden.Server.Sdk/tests/Bitwarden.Server.Sdk.IntegrationTests/SdkListDeploymentFilesTests.cs
+++ b/extensions/Bitwarden.Server.Sdk/tests/Bitwarden.Server.Sdk.IntegrationTests/SdkListDeploymentFilesTests.cs
@@ -1,0 +1,292 @@
+using Microsoft.Build.Utilities.ProjectCreation;
+
+namespace Bitwarden.Server.Sdk.IntegrationTests;
+
+public class SdkListDeploymentFilesTests : MSBuildTestBase
+{
+    private static readonly string SdkPropsPath = Path.Combine(
+        Path.GetDirectoryName(typeof(SdkListDeploymentFilesTests).Assembly.Location)!,
+        "Sdk", "Sdk.props");
+
+    private static readonly string SdkTargetsPath = Path.Combine(
+        Path.GetDirectoryName(typeof(SdkListDeploymentFilesTests).Assembly.Location)!,
+        "Sdk", "Sdk.targets");
+
+    private static ProjectCreator CreateProject(string path) =>
+        ProjectCreator.Templates.SdkCsproj(
+                path: path,
+                sdk: "Microsoft.NET.Sdk",
+                targetFramework: "net10.0")
+            .Import(SdkPropsPath)
+            .Import(SdkTargetsPath);
+
+    [Fact]
+    public void ListDeploymentFiles_IncludesCsprojPath()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(dir);
+
+        CreateProject(Path.Combine(dir, "Test.csproj"))
+            .TryBuild("ListDeploymentFiles", out var result, out var buildOutput);
+
+        Assert.True(result, buildOutput.GetConsoleLog());
+        Assert.Contains(buildOutput.MessageEvents,
+            m => m.Message?.EndsWith("Test.csproj", StringComparison.OrdinalIgnoreCase) == true);
+    }
+
+    [Fact]
+    public void ListDeploymentFiles_IncludesSourceFiles()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "MyClass.cs"), "public class MyClass {}");
+
+        CreateProject(Path.Combine(dir, "Test.csproj"))
+            .TryBuild("ListDeploymentFiles", out var result, out var buildOutput);
+
+        Assert.True(result, buildOutput.GetConsoleLog());
+        Assert.Contains(buildOutput.MessageEvents,
+            m => m.Message?.EndsWith("MyClass.cs", StringComparison.OrdinalIgnoreCase) == true);
+    }
+
+    [Fact]
+    public void ListDeploymentFiles_IncludesBitDeploymentInputItems()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "appsettings.json"), "{}");
+
+        CreateProject(Path.Combine(dir, "Test.csproj"))
+            .ItemInclude("BitDeploymentInput", "appsettings.json")
+            .TryBuild("ListDeploymentFiles", out var result, out var buildOutput);
+
+        Assert.True(result, buildOutput.GetConsoleLog());
+        Assert.Contains(buildOutput.MessageEvents,
+            m => m.Message?.EndsWith("appsettings.json", StringComparison.OrdinalIgnoreCase) == true);
+    }
+
+    [Fact]
+    public void ListDeploymentFiles_NoDuplicatesWithDiamondDependencies()
+    {
+        var dDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(dDir);
+        File.WriteAllText(Path.Combine(dDir, "D.cs"), "public class D {}");
+        var dProject = CreateProject(Path.Combine(dDir, "D.csproj")).Save();
+
+        var bDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(bDir);
+        var bProject = CreateProject(Path.Combine(bDir, "B.csproj"))
+            .ItemProjectReference(dProject.FullPath)
+            .Save();
+
+        var cDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(cDir);
+        var cProject = CreateProject(Path.Combine(cDir, "C.csproj"))
+            .ItemProjectReference(dProject.FullPath)
+            .Save();
+
+        var aDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(aDir);
+
+        CreateProject(Path.Combine(aDir, "A.csproj"))
+            .ItemProjectReference(bProject.FullPath)
+            .ItemProjectReference(cProject.FullPath)
+            .TryBuild("ListDeploymentFiles", out var result, out var buildOutput);
+
+        Assert.True(result, buildOutput.GetConsoleLog());
+
+        var messages = buildOutput.MessageEvents
+            .Select(m => m.Message)
+            .Where(m => m is not null)
+            .ToList();
+
+        Assert.Single(messages, m => m!.EndsWith("D.csproj", StringComparison.OrdinalIgnoreCase));
+        Assert.Single(messages, m => m!.EndsWith("D.cs", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void ListDeploymentFiles_IncludesFilesFromProjectReferences()
+    {
+        var libDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(libDir);
+        File.WriteAllText(Path.Combine(libDir, "LibClass.cs"), "public class LibClass {}");
+        var libProject = CreateProject(Path.Combine(libDir, "Lib.csproj")).Save();
+
+        var appDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(appDir);
+        File.WriteAllText(Path.Combine(appDir, "AppClass.cs"), "public class AppClass {}");
+
+        CreateProject(Path.Combine(appDir, "App.csproj"))
+            .ItemProjectReference(libProject.FullPath)
+            .TryBuild("ListDeploymentFiles", out var result, out var buildOutput);
+
+        Assert.True(result, buildOutput.GetConsoleLog());
+
+        var messages = buildOutput.MessageEvents.Select(m => m.Message).ToList();
+        Assert.Contains(messages, m => m?.EndsWith("AppClass.cs", StringComparison.OrdinalIgnoreCase) == true);
+        Assert.Contains(messages, m => m?.EndsWith("LibClass.cs", StringComparison.OrdinalIgnoreCase) == true);
+    }
+
+    [Fact]
+    public void ListDeploymentFiles_IncludesEmbeddedResources()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "Strings.resx"), "<root />");
+
+        CreateProject(Path.Combine(dir, "Test.csproj"))
+            .ItemInclude("EmbeddedResource", "Strings.resx")
+            .TryBuild("ListDeploymentFiles", out var result, out var buildOutput);
+
+        Assert.True(result, buildOutput.GetConsoleLog());
+        Assert.Contains(buildOutput.MessageEvents,
+            m => m.Message?.EndsWith("Strings.resx", StringComparison.OrdinalIgnoreCase) == true);
+    }
+
+    [Fact]
+    public void ListDeploymentFiles_IncludesContentCopiedToOutput_ExcludesNever()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "appsettings.json"), "{}");
+        File.WriteAllText(Path.Combine(dir, "template.txt"), "template");
+
+        CreateProject(Path.Combine(dir, "Test.csproj"))
+            .ItemInclude("Content", "appsettings.json", metadata: new Dictionary<string, string?>
+            {
+                { "CopyToOutputDirectory", "PreserveNewest" },
+            })
+            .ItemInclude("Content", "template.txt", metadata: new Dictionary<string, string?>
+            {
+                { "CopyToOutputDirectory", "Never" },
+            })
+            .TryBuild("ListDeploymentFiles", out var result, out var buildOutput);
+
+        Assert.True(result, buildOutput.GetConsoleLog());
+
+        var messages = buildOutput.MessageEvents.Select(m => m.Message).ToList();
+        Assert.Contains(messages, m => m?.EndsWith("appsettings.json", StringComparison.OrdinalIgnoreCase) == true);
+        Assert.DoesNotContain(messages, m => m?.EndsWith("template.txt", StringComparison.OrdinalIgnoreCase) == true);
+    }
+
+    [Fact]
+    public void ListDeploymentFiles_IncludesLockFileWhenEnabled()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "packages.lock.json"), "{}");
+
+        CreateProject(Path.Combine(dir, "Test.csproj"))
+            .Property("RestorePackagesWithLockFile", "true")
+            .TryBuild("ListDeploymentFiles", out var result, out var buildOutput);
+
+        Assert.True(result, buildOutput.GetConsoleLog());
+        Assert.Contains(buildOutput.MessageEvents,
+            m => m.Message?.EndsWith("packages.lock.json", StringComparison.OrdinalIgnoreCase) == true);
+    }
+
+    [Fact]
+    public void ListDeploymentFiles_ExcludesLockFileWhenDisabled()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "packages.lock.json"), "{}");
+
+        CreateProject(Path.Combine(dir, "Test.csproj"))
+            .TryBuild("ListDeploymentFiles", out var result, out var buildOutput);
+
+        Assert.True(result, buildOutput.GetConsoleLog());
+        Assert.DoesNotContain(buildOutput.MessageEvents,
+            m => m.Message?.EndsWith("packages.lock.json", StringComparison.OrdinalIgnoreCase) == true);
+    }
+
+    [Fact]
+    public void ListDeploymentFiles_RespectsCustomLockFilePath()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(dir);
+        var lockFilePath = Path.Combine(dir, "custom.lock.json");
+        File.WriteAllText(lockFilePath, "{}");
+
+        CreateProject(Path.Combine(dir, "Test.csproj"))
+            .Property("RestorePackagesWithLockFile", "true")
+            .Property("NuGetLockFilePath", lockFilePath)
+            .TryBuild("ListDeploymentFiles", out var result, out var buildOutput);
+
+        Assert.True(result, buildOutput.GetConsoleLog());
+        Assert.Contains(buildOutput.MessageEvents,
+            m => m.Message?.EndsWith("custom.lock.json", StringComparison.OrdinalIgnoreCase) == true);
+    }
+
+    [Fact]
+    public void WriteDeploymentFiles_WritesFileToDefaultPath()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "MyClass.cs"), "public class MyClass {}");
+
+        CreateProject(Path.Combine(dir, "Test.csproj"))
+            .TryBuild("WriteDeploymentFiles", out var result, out var buildOutput);
+
+        Assert.True(result, buildOutput.GetConsoleLog());
+
+        var outputPath = Path.Combine(dir, "obj", "deployment-files.txt");
+        Assert.True(File.Exists(outputPath));
+
+        var lines = File.ReadAllLines(outputPath);
+        Assert.Contains(lines, l => l.EndsWith("Test.csproj", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(lines, l => l.EndsWith("MyClass.cs", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void WriteDeploymentFiles_RespectsCustomOutputPath()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(dir);
+        var outputPath = Path.Combine(dir, "custom-output.txt");
+
+        CreateProject(Path.Combine(dir, "Test.csproj"))
+            .Property("DeploymentFilesOutputPath", outputPath)
+            .TryBuild("WriteDeploymentFiles", out var result, out var buildOutput);
+
+        Assert.True(result, buildOutput.GetConsoleLog());
+        Assert.True(File.Exists(outputPath));
+    }
+
+    [Fact]
+    public void WriteDeploymentFiles_NoDuplicatesWithDiamondDependencies()
+    {
+        var dDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(dDir);
+        File.WriteAllText(Path.Combine(dDir, "D.cs"), "public class D {}");
+        var dProject = CreateProject(Path.Combine(dDir, "D.csproj")).Save();
+
+        var bDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(bDir);
+        var bProject = CreateProject(Path.Combine(bDir, "B.csproj"))
+            .ItemProjectReference(dProject.FullPath)
+            .Save();
+
+        var cDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(cDir);
+        var cProject = CreateProject(Path.Combine(cDir, "C.csproj"))
+            .ItemProjectReference(dProject.FullPath)
+            .Save();
+
+        var aDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(aDir);
+        var outputPath = Path.Combine(aDir, "deployment-files.txt");
+
+        CreateProject(Path.Combine(aDir, "A.csproj"))
+            .ItemProjectReference(bProject.FullPath)
+            .ItemProjectReference(cProject.FullPath)
+            .Property("DeploymentFilesOutputPath", outputPath)
+            .TryBuild("WriteDeploymentFiles", out var result, out var buildOutput);
+
+        Assert.True(result, buildOutput.GetConsoleLog());
+
+        var lines = File.ReadAllLines(outputPath);
+        Assert.Single(lines, l => l.EndsWith("D.csproj", StringComparison.OrdinalIgnoreCase));
+        Assert.Single(lines, l => l.EndsWith("D.cs", StringComparison.OrdinalIgnoreCase));
+    }
+}


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Adds an MSBuild target to the server SDK that enables you to call `dotnet msbuild -t:ListDeploymentFiles` (and similar helpers)
this lists files that would affect the output of the program, this is meant to be used as part of a CI gate to determine if
a service of yours has recieved any changes and should be deployed. This helps avoid unnecessary releases, especially in a 
monorepository. 

## 🚨 Breaking Changes

<!-- Does this PR introduce breaking changes for downstream .NET consumers? If yes, document them clearly.

If breaking changes exist:
1. Describe the public API, behavior, or configuration change
2. Explain why the change was necessary
3. Provide concrete migration steps for client developers
4. Link to any related or coordinated PRs/releases

If there are no breaking changes, delete this section. -->
