### PR TITLE
Fix docs referencing old json object style return

### DIFF
--- a/extensions/Bitwarden.Server.Sdk.WebEssentials/src/PACKAGE.md
+++ b/extensions/Bitwarden.Server.Sdk.WebEssentials/src/PACKAGE.md
@@ -45,7 +45,7 @@ app.MapVersionEndpoint();
 Example response:
 
 ```json
-{ "version": "1.2.3" }
+"1.2.3"
 ```
 
 The version is read from the application assembly's `AssemblyInformationalVersion`.


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

The docs were showing that we return a JSON object with the version as a property still even though we updated the library to return a JSON string literal with the version.

## 🚨 Breaking Changes

<!-- Does this PR introduce breaking changes for downstream .NET consumers? If yes, document them clearly.

If breaking changes exist:
1. Describe the public API, behavior, or configuration change
2. Explain why the change was necessary
3. Provide concrete migration steps for client developers
4. Link to any related or coordinated PRs/releases

If there are no breaking changes, delete this section. -->
