### PR TITLE
Fix Dependency injection analyzer that is supposed to come with the SDK

### DIFF
--- a/extensions/Bitwarden.Server.Sdk/src/Sdk/Sdk.props
+++ b/extensions/Bitwarden.Server.Sdk/src/Sdk/Sdk.props
@@ -3,4 +3,13 @@
   <PropertyGroup>
     <UsingBitwardenServerSdk>true</UsingBitwardenServerSdk>
   </PropertyGroup>
+
+  <!--
+    When consumed as an MSBuild SDK, NuGet does not automatically register assemblies
+    placed in analyzers/dotnet/cs/ — we must explicitly add them as Analyzer items.
+  -->
+  <ItemGroup>
+    <Analyzer Include="$(MSBuildThisFileDirectory)..\analyzers\dotnet\cs\Bitwarden.Server.Sdk.Analyzers.dll" />
+    <Analyzer Include="$(MSBuildThisFileDirectory)..\analyzers\dotnet\cs\Bitwarden.Server.Sdk.CodeFixers.dll" />
+  </ItemGroup>
 </Project>

--- a/extensions/Bitwarden.Server.Sdk/tests/Bitwarden.Server.Sdk.IntegrationTests/Bitwarden.Server.Sdk.IntegrationTests.csproj
+++ b/extensions/Bitwarden.Server.Sdk/tests/Bitwarden.Server.Sdk.IntegrationTests/Bitwarden.Server.Sdk.IntegrationTests.csproj
@@ -32,6 +32,13 @@
     <None Include="..\..\src\Sdk\**\*" Link="Sdk\%(RecursiveDir)%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
 
     <None Include="..\..\src\Content\**\*" Link="Content\%(RecursiveDir)%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
+
+    <!--
+      Sdk.props registers analyzers at analyzers/dotnet/cs/ relative to itself (i.e. relative to the Sdk/ directory).
+      Copy the built DLLs there so the in-process MSBuild tests can resolve them.
+    -->
+    <None Include="..\..\analyzers\Bitwarden.Server.Sdk.Analyzers\bin\$(Configuration)\netstandard2.0\Bitwarden.Server.Sdk.Analyzers.dll" Link="analyzers\dotnet\cs\Bitwarden.Server.Sdk.Analyzers.dll" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="..\..\analyzers\Bitwarden.Server.Sdk.CodeFixers\bin\$(Configuration)\netstandard2.0\Bitwarden.Server.Sdk.CodeFixers.dll" Link="analyzers\dotnet\cs\Bitwarden.Server.Sdk.CodeFixers.dll" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <!-- All local features -->
@@ -42,6 +49,10 @@
 
     <!-- Create a project reference for each Sdk package -->
     <ProjectReference Include="@(SdkPackage->'..\..\..\Bitwarden.Server.Sdk.%(Identity)\src\Bitwarden.Server.Sdk.%(Identity).csproj')" />
+
+    <!-- Build-order-only references to ensure analyzer DLLs exist before tests copy them to output -->
+    <ProjectReference Include="..\..\analyzers\Bitwarden.Server.Sdk.Analyzers\Bitwarden.Server.Sdk.Analyzers.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\analyzers\Bitwarden.Server.Sdk.CodeFixers\Bitwarden.Server.Sdk.CodeFixers.csproj" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
 </Project>

--- a/extensions/Bitwarden.Server.Sdk/tests/Bitwarden.Server.Sdk.IntegrationTests/SdkTests.cs
+++ b/extensions/Bitwarden.Server.Sdk/tests/Bitwarden.Server.Sdk.IntegrationTests/SdkTests.cs
@@ -7,6 +7,21 @@ namespace Bitwarden.Server.Sdk.IntegrationTests;
 public class SdkTests : MSBuildTestBase
 {
     [Fact]
+    public void AnalyzerDiagnosticIsEmitted_WhenUsingAddSingletonInsteadOfTryAdd()
+    {
+        ProjectCreator.Templates.SdkProject(
+            out var result,
+            out var buildOutput,
+            additional: """
+                builder.Services.AddSingleton<System.IDisposable, System.IO.MemoryStream>();
+                """
+        );
+
+        Assert.True(result, buildOutput.GetConsoleLog());
+        Assert.Contains(buildOutput.WarningEvents, w => w.Code == "BW0003");
+    }
+
+    [Fact]
     public void NoOverridingProperties_CanCompile()
     {
         IEnumerable<(string Feature, bool DefaultValue)> featuresAndDefaults = [


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

The DI analyzer is not working once I have bumped the server sdk to `1.6.0` in `server`. This registers them manually since msbuild sdks don't automatically add analyzers that are in their `analyzers` folder like normal nuget packages do. 

## 🚨 Breaking Changes

<!-- Does this PR introduce breaking changes for downstream .NET consumers? If yes, document them clearly.

If breaking changes exist:
1. Describe the public API, behavior, or configuration change
2. Explain why the change was necessary
3. Provide concrete migration steps for client developers
4. Link to any related or coordinated PRs/releases

If there are no breaking changes, delete this section. -->
