### PR TITLE
fix: Improve feature flag code fixer pattern handling

### DIFF
--- a/extensions/Bitwarden.Server.Sdk.Features/analyzers/Bitwarden.Server.Sdk.Features.CodeFixers/RemoveFeatureFlagCodeFixer.cs
+++ b/extensions/Bitwarden.Server.Sdk.Features/analyzers/Bitwarden.Server.Sdk.Features.CodeFixers/RemoveFeatureFlagCodeFixer.cs
@@ -191,6 +191,11 @@ public class RemoveFeatureFlagCodeFixer : CodeFixProvider
             PrefixUnaryExpressionSyntax { RawKind: (int)SyntaxKind.LogicalNotExpression, Parent: IfStatementSyntax ifStatement } =>
                 root.ReplaceNode(ifStatement, GetStatements(ifStatement.Else?.Statement, ifStatement.GetLeadingTrivia())),
 
+            // !IsEnabled(flag) is one operand of a binary expression (e.g. condition && !flag).
+            // Strip only the flag operand; keep the rest of the binary so guards like `x is not null` are preserved.
+            PrefixUnaryExpressionSyntax { RawKind: (int)SyntaxKind.LogicalNotExpression, Parent: BinaryExpressionSyntax binaryExpression } prefixUnary =>
+                root.ReplaceNode(binaryExpression, SimplifyBinary(binaryExpression, prefixUnary)),
+
             // expr is false — flag is always-on (true), so condition is always false; keep else, drop then.
             IsPatternExpressionSyntax
             {

--- a/extensions/Bitwarden.Server.Sdk.Features/analyzers/Bitwarden.Server.Sdk.Features.CodeFixers/RemoveFeatureFlagCodeFixer.cs
+++ b/extensions/Bitwarden.Server.Sdk.Features/analyzers/Bitwarden.Server.Sdk.Features.CodeFixers/RemoveFeatureFlagCodeFixer.cs
@@ -191,11 +191,6 @@ public class RemoveFeatureFlagCodeFixer : CodeFixProvider
             PrefixUnaryExpressionSyntax { RawKind: (int)SyntaxKind.LogicalNotExpression, Parent: IfStatementSyntax ifStatement } =>
                 root.ReplaceNode(ifStatement, GetStatements(ifStatement.Else?.Statement, ifStatement.GetLeadingTrivia())),
 
-            // !IsEnabled(flag) is one operand of a binary expression (e.g. condition && !flag).
-            // Strip only the flag operand; keep the rest of the binary so guards like `x is not null` are preserved.
-            PrefixUnaryExpressionSyntax { RawKind: (int)SyntaxKind.LogicalNotExpression, Parent: BinaryExpressionSyntax binaryExpression } prefixUnary =>
-                root.ReplaceNode(binaryExpression, SimplifyBinary(binaryExpression, prefixUnary)),
-
             // expr is false — flag is always-on (true), so condition is always false; keep else, drop then.
             IsPatternExpressionSyntax
             {

--- a/extensions/Bitwarden.Server.Sdk.Features/analyzers/Bitwarden.Server.Sdk.Features.CodeFixers/RemoveFeatureFlagCodeFixer.cs
+++ b/extensions/Bitwarden.Server.Sdk.Features/analyzers/Bitwarden.Server.Sdk.Features.CodeFixers/RemoveFeatureFlagCodeFixer.cs
@@ -263,6 +263,29 @@ public class RemoveFeatureFlagCodeFixer : CodeFixProvider
             root = root.ReplaceNode(isPattern, replacement);
         }
 
+        // Fold negated is-pattern expressions whose operand has reduced to a boolean literal:
+        // e.g. `true is not true` → `false`, `true is not false` → `true`.
+        var isNotPatternToFold = root.DescendantNodes()
+            .OfType<IsPatternExpressionSyntax>()
+            .Where(static ip =>
+                ip.Expression is LiteralExpressionSyntax exprLit &&
+                (exprLit.IsKind(SyntaxKind.TrueLiteralExpression) || exprLit.IsKind(SyntaxKind.FalseLiteralExpression)) &&
+                ip.Pattern is UnaryPatternSyntax { Pattern: ConstantPatternSyntax { Expression: LiteralExpressionSyntax patLit } } &&
+                (patLit.IsKind(SyntaxKind.TrueLiteralExpression) || patLit.IsKind(SyntaxKind.FalseLiteralExpression)))
+            .ToList();
+
+        foreach (var isPattern in isNotPatternToFold)
+        {
+            var exprLit = (LiteralExpressionSyntax)isPattern.Expression;
+            var innerPatLit = (LiteralExpressionSyntax)((ConstantPatternSyntax)((UnaryPatternSyntax)isPattern.Pattern).Pattern).Expression;
+            // `is not` inverts the match — same literal → false, different → true.
+            var matches = exprLit.IsKind(SyntaxKind.TrueLiteralExpression) == innerPatLit.IsKind(SyntaxKind.TrueLiteralExpression);
+            var replacement = matches
+                ? SyntaxFactory.LiteralExpression(SyntaxKind.FalseLiteralExpression).WithTriviaFrom(isPattern)
+                : SyntaxFactory.LiteralExpression(SyntaxKind.TrueLiteralExpression).WithTriviaFrom(isPattern);
+            root = root.ReplaceNode(isPattern, replacement);
+        }
+
         // Find all ternary expressions with literal boolean conditions
         var ternariesToSimplify = root.DescendantNodes()
             .OfType<ConditionalExpressionSyntax>()

--- a/extensions/Bitwarden.Server.Sdk.Features/analyzers/Bitwarden.Server.Sdk.Features.CodeFixers/RemoveFeatureFlagCodeFixer.cs
+++ b/extensions/Bitwarden.Server.Sdk.Features/analyzers/Bitwarden.Server.Sdk.Features.CodeFixers/RemoveFeatureFlagCodeFixer.cs
@@ -689,6 +689,8 @@ public class RemoveFeatureFlagCodeFixer : CodeFixProvider
         if (!secondArg.Value.ConstantValue.HasValue
             && secondArg.Value is IParameterReferenceOperation { Parameter: var param }
             && returnsAccess.FirstAncestorOrSelf<MethodDeclarationSyntax>() is { } theoryMethod
+            && theoryMethod.ParameterList.Parameters is [{ } onlyParam]
+            && onlyParam.Identifier.Text == param.Name
             && IsTheoryWithBoolInlineData(theoryMethod)
             && IsParameterOnlyUsedOnce(theoryMethod, param.Name))
         {

--- a/extensions/Bitwarden.Server.Sdk.Features/analyzers/Bitwarden.Server.Sdk.Features.CodeFixers/RemoveFeatureFlagCodeFixer.cs
+++ b/extensions/Bitwarden.Server.Sdk.Features/analyzers/Bitwarden.Server.Sdk.Features.CodeFixers/RemoveFeatureFlagCodeFixer.cs
@@ -190,6 +190,14 @@ public class RemoveFeatureFlagCodeFixer : CodeFixProvider
             PrefixUnaryExpressionSyntax { RawKind: (int)SyntaxKind.LogicalNotExpression, Parent: IfStatementSyntax ifStatement } =>
                 root.ReplaceNode(ifStatement, GetStatements(ifStatement.Else?.Statement, ifStatement.GetLeadingTrivia())),
 
+            // expr is false — flag is always-on (true), so condition is always false; keep else, drop then.
+            IsPatternExpressionSyntax
+            {
+                Pattern: ConstantPatternSyntax { Expression: LiteralExpressionSyntax { } patternLiteral },
+                Parent: IfStatementSyntax isPatternIfStatement
+            } when patternLiteral.IsKind(SyntaxKind.FalseLiteralExpression) =>
+                root.ReplaceNode(isPatternIfStatement, GetStatements(isPatternIfStatement.Else?.Statement, isPatternIfStatement.GetLeadingTrivia())),
+
             IfStatementSyntax ifStatement =>
                 root.ReplaceNode(ifStatement, GetStatements(ifStatement.Statement, ifStatement.GetLeadingTrivia())),
 
@@ -228,6 +236,28 @@ public class RemoveFeatureFlagCodeFixer : CodeFixProvider
 
     private static SyntaxNode SimplifyBooleanExpressions(SyntaxNode root)
     {
+        // Fold is-pattern expressions whose operand has reduced to a boolean literal:
+        // e.g. `true is false` → `false`, `true is true` → `true`.
+        var isPatternToFold = root.DescendantNodes()
+            .OfType<IsPatternExpressionSyntax>()
+            .Where(static ip =>
+                ip.Expression is LiteralExpressionSyntax exprLit &&
+                (exprLit.IsKind(SyntaxKind.TrueLiteralExpression) || exprLit.IsKind(SyntaxKind.FalseLiteralExpression)) &&
+                ip.Pattern is ConstantPatternSyntax { Expression: LiteralExpressionSyntax patLit } &&
+                (patLit.IsKind(SyntaxKind.TrueLiteralExpression) || patLit.IsKind(SyntaxKind.FalseLiteralExpression)))
+            .ToList();
+
+        foreach (var isPattern in isPatternToFold)
+        {
+            var exprLit = (LiteralExpressionSyntax)isPattern.Expression;
+            var patLit = (LiteralExpressionSyntax)((ConstantPatternSyntax)isPattern.Pattern).Expression;
+            var matches = exprLit.IsKind(SyntaxKind.TrueLiteralExpression) == patLit.IsKind(SyntaxKind.TrueLiteralExpression);
+            var replacement = matches
+                ? SyntaxFactory.LiteralExpression(SyntaxKind.TrueLiteralExpression).WithTriviaFrom(isPattern)
+                : SyntaxFactory.LiteralExpression(SyntaxKind.FalseLiteralExpression).WithTriviaFrom(isPattern);
+            root = root.ReplaceNode(isPattern, replacement);
+        }
+
         // Find all ternary expressions with literal boolean conditions
         var ternariesToSimplify = root.DescendantNodes()
             .OfType<ConditionalExpressionSyntax>()

--- a/extensions/Bitwarden.Server.Sdk.Features/analyzers/Bitwarden.Server.Sdk.Features.CodeFixers/RemoveFeatureFlagCodeFixer.cs
+++ b/extensions/Bitwarden.Server.Sdk.Features/analyzers/Bitwarden.Server.Sdk.Features.CodeFixers/RemoveFeatureFlagCodeFixer.cs
@@ -11,7 +11,8 @@ using Microsoft.CodeAnalysis.Operations;
 
 namespace Bitwarden.Server.Sdk.Features.CodeFixers;
 
-internal record MockReturnInfo(bool ReturnsFalse, MemberDeclarationSyntax? TestMethod, ExpressionStatementSyntax? ExpressionStatement);
+internal record TheoryConversionInfo(MethodDeclarationSyntax Method, string ParamName);
+internal record MockReturnInfo(bool ReturnsFalse, MemberDeclarationSyntax? TestMethod, ExpressionStatementSyntax? ExpressionStatement, TheoryConversionInfo? TheoryConversion = null);
 
 [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(RemoveFeatureFlagCodeFixer))]
 public class RemoveFeatureFlagCodeFixer : CodeFixProvider
@@ -116,7 +117,7 @@ public class RemoveFeatureFlagCodeFixer : CodeFixProvider
             // Also track mock-related nodes (TestMethod, ExpressionStatement) so GetCurrentNode
             // works correctly after earlier fixes shrink or restructure the tree.
             var extraNodesToTrack = mockAnalysis.Values
-                .SelectMany(mi => new SyntaxNode?[] { mi.TestMethod, mi.ExpressionStatement })
+                .SelectMany(mi => new SyntaxNode?[] { mi.TestMethod, mi.ExpressionStatement, mi.TheoryConversion?.Method })
                 .OfType<SyntaxNode>();
 
             // Use TrackNodes to maintain node identity across replacements
@@ -216,13 +217,17 @@ public class RemoveFeatureFlagCodeFixer : CodeFixProvider
                     newSyntax = root.RemoveNode(testMethodInRoot, SyntaxRemoveOptions.KeepNoTrivia);
                 }
             }
+            else if (mockInfo.TheoryConversion is not null)
+            {
+                newSyntax = ConvertTheoryToFact(root, mockInfo.TheoryConversion, mockInfo.ExpressionStatement);
+            }
             else if (mockInfo.ExpressionStatement is not null)
             {
                 // Delete the whole expression of the mock - use GetCurrentNode for the same reason.
                 var expressionInRoot = root.GetCurrentNode(mockInfo.ExpressionStatement);
                 if (expressionInRoot is not null)
                 {
-                    newSyntax = root.RemoveNode(expressionInRoot, SyntaxRemoveOptions.KeepTrailingTrivia);
+                    newSyntax = RemoveNodeCleanly(root, expressionInRoot);
                 }
             }
         }
@@ -551,9 +556,91 @@ public class RemoveFeatureFlagCodeFixer : CodeFixProvider
         return newRoot.RemoveNode(newRoot.FindNode(nodeToRemove.Span), SyntaxRemoveOptions.KeepNoTrivia)!;
     }
 
+    private static SyntaxNode ConvertTheoryToFact(SyntaxNode root, TheoryConversionInfo info, ExpressionStatementSyntax? expressionStatement)
+    {
+        // Step 1: remove the Returns(...) expression statement first so the method node
+        // stays in the tree and GetCurrentNode still resolves it in step 2.
+        if (expressionStatement is not null)
+        {
+            var currentExpr = root.GetCurrentNode(expressionStatement);
+            if (currentExpr is not null)
+            {
+                root = RemoveNodeCleanly(root, currentExpr);
+            }
+        }
+
+        // Step 2: get the (now possibly shrunk) method from the updated root.
+        if (root.GetCurrentNode(info.Method) is not MethodDeclarationSyntax currentMethod)
+        {
+            return root;
+        }
+
+        // Step 3: swap [Theory] → [Fact] and drop all [InlineData] attribute lists.
+        var newAttributeLists = currentMethod.AttributeLists
+            .Select(al =>
+            {
+                var kept = al.Attributes
+                    .Where(a => !a.Name.ToString().Contains("InlineData"))
+                    .Select(a => a.Name.ToString().Contains("Theory")
+                        ? a.WithName(SyntaxFactory.IdentifierName("Fact"))
+                        : a)
+                    .ToList();
+                return kept.Count == 0 ? null : al.WithAttributes(SyntaxFactory.SeparatedList(kept));
+            })
+            .OfType<AttributeListSyntax>()
+            .ToList();
+
+        var newMethod = currentMethod.WithAttributeLists(SyntaxFactory.List(newAttributeLists));
+
+        // Step 4: remove the bool parameter from the method signature.
+        var paramToRemove = newMethod.ParameterList.Parameters
+            .FirstOrDefault(p => p.Identifier.Text == info.ParamName);
+        if (paramToRemove is not null)
+        {
+            newMethod = newMethod.WithParameterList(
+                newMethod.ParameterList.WithParameters(
+                    newMethod.ParameterList.Parameters.Remove(paramToRemove)));
+        }
+
+        return root.ReplaceNode(currentMethod, newMethod.WithAdditionalAnnotations(Formatter.Annotation));
+    }
+
+    private static bool IsTheoryWithBoolInlineData(MethodDeclarationSyntax method)
+    {
+        var attributes = method.AttributeLists.SelectMany(al => al.Attributes).ToList();
+
+        if (!attributes.Any(a => a.Name.ToString() is "Theory" or "TheoryAttribute"))
+        {
+            return false;
+        }
+
+        // Only handle the simple case: exactly two single-argument [InlineData] attributes,
+        // one with `true` and one with `false`.
+        var inlineDataValues = attributes
+            .Where(a => a.Name.ToString() is "InlineData" or "InlineDataAttribute")
+            .Select(a => a.ArgumentList?.Arguments)
+            .Where(args => args is { Count: 1 })
+            .Select(args => args!.Value[0].Expression)
+            .ToList();
+
+        return inlineDataValues.Count == 2
+            && inlineDataValues.Any(e => e.IsKind(SyntaxKind.TrueLiteralExpression))
+            && inlineDataValues.Any(e => e.IsKind(SyntaxKind.FalseLiteralExpression));
+    }
+
+    private static bool IsParameterOnlyUsedOnce(MethodDeclarationSyntax method, string paramName)
+    {
+        var searchRoot = (SyntaxNode?)method.Body ?? method.ExpressionBody;
+        if (searchRoot is null) return true;
+
+        return searchRoot.DescendantNodes()
+            .OfType<IdentifierNameSyntax>()
+            .Count(id => id.Identifier.Text == paramName) == 1;
+    }
+
     private static MockReturnInfo? AnalyzeMockReturns(SyntaxNode node, SemanticModel semanticModel)
     {
-        // Check pattern: featureService.IsEnabled(flag).Returns(false)
+        // Check pattern: featureService.IsEnabled(flag).Returns(...)
         if (node.FirstAncestorOrSelf<InvocationExpressionSyntax>() is not
             {
                 Expression: MemberAccessExpressionSyntax { Name.Identifier.Text: IsEnabledMethodName },
@@ -572,6 +659,19 @@ public class RemoveFeatureFlagCodeFixer : CodeFixProvider
         var testMethod = returnsFalse ? returnsAccess.FirstAncestorOrSelf<MemberDeclarationSyntax>() : null;
         var expressionStatement = returnsParent.FirstAncestorOrSelf<ExpressionStatementSyntax>();
 
-        return new MockReturnInfo(returnsFalse, testMethod, expressionStatement);
+        // Check for Theory→Fact conversion: Returns(param) where the method is a simple
+        // [Theory] with only [InlineData(true)] and [InlineData(false)], and the param
+        // is not used anywhere else in the method body.
+        TheoryConversionInfo? theoryConversion = null;
+        if (!secondArg.Value.ConstantValue.HasValue
+            && secondArg.Value is IParameterReferenceOperation { Parameter: var param }
+            && returnsAccess.FirstAncestorOrSelf<MethodDeclarationSyntax>() is { } theoryMethod
+            && IsTheoryWithBoolInlineData(theoryMethod)
+            && IsParameterOnlyUsedOnce(theoryMethod, param.Name))
+        {
+            theoryConversion = new TheoryConversionInfo(theoryMethod, param.Name);
+        }
+
+        return new MockReturnInfo(returnsFalse, testMethod, expressionStatement, theoryConversion);
     }
 }

--- a/extensions/Bitwarden.Server.Sdk.Features/tests/Bitwarden.Server.Sdk.Features.CodeFixers.Tests/RemoveFeatureFlagCodeFixerTests.cs
+++ b/extensions/Bitwarden.Server.Sdk.Features/tests/Bitwarden.Server.Sdk.Features.CodeFixers.Tests/RemoveFeatureFlagCodeFixerTests.cs
@@ -1433,6 +1433,141 @@ public class RemoveFeatureFlagCodeFixerTests : TestBase
     }
 
     [Fact]
+    public async Task TestCode_MocksNonConstant_LocalFunctionParam_OnlyRemovesReturns()
+    {
+        TestState.AdditionalReferences.Add(MetadataReference.CreateFromFile(typeof(Substitute).Assembly.Location));
+        TestState.AdditionalReferences.Add(MetadataReference.CreateFromFile(typeof(FactAttribute).Assembly.Location));
+
+        await RunDefaultCodeFixAsync("""
+            using NSubstitute;
+            using Xunit;
+            using Bitwarden.Server.Sdk.Features;
+
+            namespace Test;
+
+            public class TestClass
+            {
+                private readonly IFeatureService _featureService;
+
+                public TestClass()
+                {
+                    _featureService = Substitute.For<IFeatureService>();
+                }
+
+                [Theory]
+                [InlineData(true)]
+                [InlineData(false)]
+                public void TestMethod(bool flagValue)
+                {
+                    void Setup(bool b)
+                    {
+                        _featureService
+                            .IsEnabled(MyFlags.Flag)
+                            .Returns(b);
+                    }
+                    Setup(flagValue);
+                }
+            }
+            """,
+            """
+            using Bitwarden.Server.Sdk.Features;
+            using NSubstitute;
+            using Xunit;
+
+            namespace Test;
+
+            public class TestClass
+            {
+                private readonly IFeatureService _featureService;
+
+                public TestClass()
+                {
+                    _featureService = Substitute.For<IFeatureService>();
+                }
+
+                [Theory]
+                [InlineData(true)]
+                [InlineData(false)]
+                public void TestMethod(bool flagValue)
+                {
+                    void Setup(bool b)
+                    {
+                    }
+                    Setup(flagValue);
+                }
+            }
+            """
+        );
+    }
+
+    [Fact]
+    public async Task TestCode_MocksNonConstant_MethodHasExtraParam_OnlyRemovesReturns()
+    {
+        TestState.AdditionalReferences.Add(MetadataReference.CreateFromFile(typeof(Substitute).Assembly.Location));
+        TestState.AdditionalReferences.Add(MetadataReference.CreateFromFile(typeof(FactAttribute).Assembly.Location));
+
+        await RunDefaultCodeFixAsync("""
+            using NSubstitute;
+            using Xunit;
+            using Bitwarden.Server.Sdk.Features;
+
+            namespace Test;
+
+            public class TestClass
+            {
+                private readonly IFeatureService _featureService;
+
+                public TestClass()
+                {
+                    _featureService = Substitute.For<IFeatureService>();
+                }
+
+                [Theory]
+                [InlineData(true)]
+                [InlineData(false)]
+                public void TestMethod(bool flagValue, string value)
+                {
+                    _featureService
+                        .IsEnabled(MyFlags.Flag)
+                        .Returns(flagValue);
+
+                    DoWork(value);
+                }
+
+                private void DoWork(string v) { }
+            }
+            """,
+            """
+            using Bitwarden.Server.Sdk.Features;
+            using NSubstitute;
+            using Xunit;
+
+            namespace Test;
+
+            public class TestClass
+            {
+                private readonly IFeatureService _featureService;
+
+                public TestClass()
+                {
+                    _featureService = Substitute.For<IFeatureService>();
+                }
+
+                [Theory]
+                [InlineData(true)]
+                [InlineData(false)]
+                public void TestMethod(bool flagValue, string value)
+                {
+                    DoWork(value);
+                }
+
+                private void DoWork(string v) { }
+            }
+            """
+        );
+    }
+
+    [Fact]
     public async Task MultipleFeatureFlags_RemovesOnlySpecifiedFlag()
     {
         // This test uses RunCodeFixAsync to verify only the specified flag is removed

--- a/extensions/Bitwarden.Server.Sdk.Features/tests/Bitwarden.Server.Sdk.Features.CodeFixers.Tests/RemoveFeatureFlagCodeFixerTests.cs
+++ b/extensions/Bitwarden.Server.Sdk.Features/tests/Bitwarden.Server.Sdk.Features.CodeFixers.Tests/RemoveFeatureFlagCodeFixerTests.cs
@@ -2329,7 +2329,7 @@ public class RemoveFeatureFlagCodeFixerTests : TestBase
     }
 
     [Fact]
-    public async Task NegatedFlagInAndChain_PreservesRemainingCondition()
+    public async Task NegatedFlagInAndChain_FalseShortCircuits_RemovesBlock()
     {
         await RunDefaultCodeFixAsync(
             """
@@ -2376,62 +2376,11 @@ public class RemoveFeatureFlagCodeFixerTests : TestBase
 
                 public void Process(IFeatureService featureService)
                 {
-                    if (_condition)
-                    {
-                        DoThing();
-                    }
 
                     Continue();
                 }
 
                 private void DoThing() { }
-                private void Continue() { }
-            }
-            """
-        );
-    }
-
-    [Fact]
-    public async Task NegatedFlagOnRightOfAndChain_PreservesNullGuard()
-    {
-        await RunDefaultCodeFixAsync(
-            """
-            using Bitwarden.Server.Sdk.Features;
-
-            namespace Test;
-
-            public class MyService
-            {
-                public void Process(IFeatureService featureService, object? data)
-                {
-                    if (data is not null && !featureService.IsEnabled(MyFlags.Flag))
-                    {
-                        throw new System.InvalidOperationException();
-                    }
-
-                    Continue();
-                }
-
-                private void Continue() { }
-            }
-            """,
-            """
-            using Bitwarden.Server.Sdk.Features;
-
-            namespace Test;
-
-            public class MyService
-            {
-                public void Process(IFeatureService featureService, object? data)
-                {
-                    if (data is not null)
-                    {
-                        throw new System.InvalidOperationException();
-                    }
-
-                    Continue();
-                }
-
                 private void Continue() { }
             }
             """

--- a/extensions/Bitwarden.Server.Sdk.Features/tests/Bitwarden.Server.Sdk.Features.CodeFixers.Tests/RemoveFeatureFlagCodeFixerTests.cs
+++ b/extensions/Bitwarden.Server.Sdk.Features/tests/Bitwarden.Server.Sdk.Features.CodeFixers.Tests/RemoveFeatureFlagCodeFixerTests.cs
@@ -304,6 +304,91 @@ public class RemoveFeatureFlagCodeFixerTests : TestBase
     }
 
     [Fact]
+    public async Task ShouldInlineIfBodyWhenIsPatternNotFalse()
+    {
+        await RunDefaultCodeFixAsync(
+            """
+            using Bitwarden.Server.Sdk.Features;
+
+            namespace Test;
+
+            public class Something
+            {
+                public Something(IFeatureService featureService)
+                {
+                    if (featureService.IsEnabled(MyFlags.Flag) is not false)
+                    {
+                        Do(true);
+                    }
+                    else
+                    {
+                        Do(false);
+                    }
+                }
+
+                private void Do(bool value) { }
+            }
+            """,
+            """
+            using Bitwarden.Server.Sdk.Features;
+
+            namespace Test;
+
+            public class Something
+            {
+                public Something(IFeatureService featureService)
+                {
+                    Do(true);
+                }
+
+                private void Do(bool value) { }
+            }
+            """
+        );
+    }
+
+    [Fact]
+    public async Task ShouldRemoveIfBlockWhenIsPatternNotTrue()
+    {
+        await RunDefaultCodeFixAsync(
+            """
+            using Bitwarden.Server.Sdk.Features;
+
+            namespace Test;
+
+            public class Something
+            {
+                public Something(IFeatureService featureService)
+                {
+                    if (featureService.IsEnabled(MyFlags.Flag) is not true)
+                    {
+                        Do(true);
+                    }
+                    Do(false);
+                }
+
+                private void Do(bool value) { }
+            }
+            """,
+            """
+            using Bitwarden.Server.Sdk.Features;
+
+            namespace Test;
+
+            public class Something
+            {
+                public Something(IFeatureService featureService)
+                {
+                    Do(false);
+                }
+
+                private void Do(bool value) { }
+            }
+            """
+        );
+    }
+
+    [Fact]
     public async Task BracelessIfCheck_InlinesBody()
     {
         await RunDefaultCodeFixAsync(

--- a/extensions/Bitwarden.Server.Sdk.Features/tests/Bitwarden.Server.Sdk.Features.CodeFixers.Tests/RemoveFeatureFlagCodeFixerTests.cs
+++ b/extensions/Bitwarden.Server.Sdk.Features/tests/Bitwarden.Server.Sdk.Features.CodeFixers.Tests/RemoveFeatureFlagCodeFixerTests.cs
@@ -838,7 +838,6 @@ public class RemoveFeatureFlagCodeFixerTests : TestBase
                 [Fact]
                 public void TestMethod()
                 {
-
                 }
             }
             """
@@ -1017,14 +1016,12 @@ public class RemoveFeatureFlagCodeFixerTests : TestBase
                 [Fact]
                 public void TestMethod1()
                 {
-
                     Do();
                 }
 
                 [Fact]
                 public void TestMethod2()
                 {
-
                     Do();
                 }
 
@@ -1035,7 +1032,7 @@ public class RemoveFeatureFlagCodeFixerTests : TestBase
     }
 
     [Fact]
-    public async Task TestCode_MocksNonConstant_AddsErrorDirective()
+    public async Task TestCode_MocksNonConstant_SimpleTheory_ConvertsToFact()
     {
         TestState.AdditionalReferences.Add(MetadataReference.CreateFromFile(typeof(Substitute).Assembly.Location));
         TestState.AdditionalReferences.Add(MetadataReference.CreateFromFile(typeof(FactAttribute).Assembly.Location));
@@ -1083,13 +1080,268 @@ public class RemoveFeatureFlagCodeFixerTests : TestBase
                     _featureService = Substitute.For<IFeatureService>();
                 }
 
+                [Fact]
+                public void TestMethod()
+                {
+                }
+            }
+            """
+        );
+    }
+
+    [Fact]
+    public async Task TestCode_MocksNonConstant_ParamAlsoUsedInBody_OnlyRemovesReturns()
+    {
+        TestState.AdditionalReferences.Add(MetadataReference.CreateFromFile(typeof(Substitute).Assembly.Location));
+        TestState.AdditionalReferences.Add(MetadataReference.CreateFromFile(typeof(FactAttribute).Assembly.Location));
+
+        await RunDefaultCodeFixAsync("""
+            using NSubstitute;
+            using Xunit;
+            using Bitwarden.Server.Sdk.Features;
+
+            namespace Test;
+
+            public class TestClass
+            {
+                private readonly IFeatureService _featureService;
+
+                public TestClass()
+                {
+                    _featureService = Substitute.For<IFeatureService>();
+                }
+
                 [Theory]
                 [InlineData(true)]
                 [InlineData(false)]
                 public void TestMethod(bool flagValue)
                 {
+                    _featureService
+                        .IsEnabled(MyFlags.Flag)
+                        .Returns(flagValue);
 
+                    DoWork(flagValue);
                 }
+
+                private void DoWork(bool flag) { }
+            }
+            """,
+            """
+            using Bitwarden.Server.Sdk.Features;
+            using NSubstitute;
+            using Xunit;
+
+            namespace Test;
+
+            public class TestClass
+            {
+                private readonly IFeatureService _featureService;
+
+                public TestClass()
+                {
+                    _featureService = Substitute.For<IFeatureService>();
+                }
+
+                [Theory]
+                [InlineData(true)]
+                [InlineData(false)]
+                public void TestMethod(bool flagValue)
+                {
+                    DoWork(flagValue);
+                }
+
+                private void DoWork(bool flag) { }
+            }
+            """
+        );
+    }
+
+    [Fact]
+    public async Task TestCode_MocksNonConstant_ExtraInlineDataArgs_OnlyRemovesReturns()
+    {
+        TestState.AdditionalReferences.Add(MetadataReference.CreateFromFile(typeof(Substitute).Assembly.Location));
+        TestState.AdditionalReferences.Add(MetadataReference.CreateFromFile(typeof(FactAttribute).Assembly.Location));
+
+        await RunDefaultCodeFixAsync("""
+            using NSubstitute;
+            using Xunit;
+            using Bitwarden.Server.Sdk.Features;
+
+            namespace Test;
+
+            public class TestClass
+            {
+                private readonly IFeatureService _featureService;
+
+                public TestClass()
+                {
+                    _featureService = Substitute.For<IFeatureService>();
+                }
+
+                [Theory]
+                [InlineData(true, "foo")]
+                [InlineData(false, "bar")]
+                public void TestMethod(bool flagValue, string value)
+                {
+                    _featureService
+                        .IsEnabled(MyFlags.Flag)
+                        .Returns(flagValue);
+                }
+            }
+            """,
+            """
+            using Bitwarden.Server.Sdk.Features;
+            using NSubstitute;
+            using Xunit;
+
+            namespace Test;
+
+            public class TestClass
+            {
+                private readonly IFeatureService _featureService;
+
+                public TestClass()
+                {
+                    _featureService = Substitute.For<IFeatureService>();
+                }
+
+                [Theory]
+                [InlineData(true, "foo")]
+                [InlineData(false, "bar")]
+                public void TestMethod(bool flagValue, string value)
+                {
+                }
+            }
+            """
+        );
+    }
+
+    [Fact]
+    public async Task TestCode_MocksNonConstant_MoreThanTwoInlineData_OnlyRemovesReturns()
+    {
+        TestState.AdditionalReferences.Add(MetadataReference.CreateFromFile(typeof(Substitute).Assembly.Location));
+        TestState.AdditionalReferences.Add(MetadataReference.CreateFromFile(typeof(FactAttribute).Assembly.Location));
+
+        await RunDefaultCodeFixAsync("""
+            using NSubstitute;
+            using Xunit;
+            using Bitwarden.Server.Sdk.Features;
+
+            namespace Test;
+
+            public class TestClass
+            {
+                private readonly IFeatureService _featureService;
+
+                public TestClass()
+                {
+                    _featureService = Substitute.For<IFeatureService>();
+                }
+
+                [Theory]
+                [InlineData(true)]
+                [InlineData(false)]
+                [InlineData(true)]
+                public void TestMethod(bool flagValue)
+                {
+                    _featureService
+                        .IsEnabled(MyFlags.Flag)
+                        .Returns(flagValue);
+                }
+            }
+            """,
+            """
+            using Bitwarden.Server.Sdk.Features;
+            using NSubstitute;
+            using Xunit;
+
+            namespace Test;
+
+            public class TestClass
+            {
+                private readonly IFeatureService _featureService;
+
+                public TestClass()
+                {
+                    _featureService = Substitute.For<IFeatureService>();
+                }
+
+                [Theory]
+                [InlineData(true)]
+                [InlineData(false)]
+                [InlineData(true)]
+                public void TestMethod(bool flagValue)
+                {
+                }
+            }
+            """
+        );
+    }
+
+    [Fact]
+    public async Task TestCode_MocksNonConstant_ParamUsedTwiceInBody_OnlyRemovesReturns()
+    {
+        TestState.AdditionalReferences.Add(MetadataReference.CreateFromFile(typeof(Substitute).Assembly.Location));
+        TestState.AdditionalReferences.Add(MetadataReference.CreateFromFile(typeof(FactAttribute).Assembly.Location));
+
+        await RunDefaultCodeFixAsync("""
+            using NSubstitute;
+            using Xunit;
+            using Bitwarden.Server.Sdk.Features;
+
+            namespace Test;
+
+            public class TestClass
+            {
+                private readonly IFeatureService _featureService;
+
+                public TestClass()
+                {
+                    _featureService = Substitute.For<IFeatureService>();
+                }
+
+                [Theory]
+                [InlineData(true)]
+                [InlineData(false)]
+                public void TestMethod(bool flagValue)
+                {
+                    _featureService
+                        .IsEnabled(MyFlags.Flag)
+                        .Returns(flagValue);
+
+                    DoWork(flagValue);
+                    DoWork(flagValue);
+                }
+
+                private void DoWork(bool flag) { }
+            }
+            """,
+            """
+            using Bitwarden.Server.Sdk.Features;
+            using NSubstitute;
+            using Xunit;
+
+            namespace Test;
+
+            public class TestClass
+            {
+                private readonly IFeatureService _featureService;
+
+                public TestClass()
+                {
+                    _featureService = Substitute.For<IFeatureService>();
+                }
+
+                [Theory]
+                [InlineData(true)]
+                [InlineData(false)]
+                public void TestMethod(bool flagValue)
+                {
+                    DoWork(flagValue);
+                    DoWork(flagValue);
+                }
+
+                private void DoWork(bool flag) { }
             }
             """
         );

--- a/extensions/Bitwarden.Server.Sdk.Features/tests/Bitwarden.Server.Sdk.Features.CodeFixers.Tests/RemoveFeatureFlagCodeFixerTests.cs
+++ b/extensions/Bitwarden.Server.Sdk.Features/tests/Bitwarden.Server.Sdk.Features.CodeFixers.Tests/RemoveFeatureFlagCodeFixerTests.cs
@@ -219,6 +219,91 @@ public class RemoveFeatureFlagCodeFixerTests : TestBase
     }
 
     [Fact]
+    public async Task ShouldInlineIfBodyWhenIsPatternTrue()
+    {
+        await RunDefaultCodeFixAsync(
+            """
+            using Bitwarden.Server.Sdk.Features;
+
+            namespace Test;
+
+            public class Something
+            {
+                public Something(IFeatureService featureService)
+                {
+                    if (featureService.IsEnabled(MyFlags.Flag) is true)
+                    {
+                        Do(true);
+                    }
+                    else
+                    {
+                        Do(false);
+                    }
+                }
+
+                private void Do(bool value) { }
+            }
+            """,
+            """
+            using Bitwarden.Server.Sdk.Features;
+
+            namespace Test;
+
+            public class Something
+            {
+                public Something(IFeatureService featureService)
+                {
+                    Do(true);
+                }
+
+                private void Do(bool value) { }
+            }
+            """
+        );
+    }
+
+    [Fact]
+    public async Task ShouldRemoveIfBlockWhenIsPatternFalse()
+    {
+        await RunDefaultCodeFixAsync(
+            """
+            using Bitwarden.Server.Sdk.Features;
+
+            namespace Test;
+
+            public class Something
+            {
+                public Something(IFeatureService featureService)
+                {
+                    if (featureService.IsEnabled(MyFlags.Flag) is false)
+                    {
+                        Do(true);
+                    }
+                    Do(false);
+                }
+
+                private void Do(bool value) { }
+            }
+            """,
+            """
+            using Bitwarden.Server.Sdk.Features;
+
+            namespace Test;
+
+            public class Something
+            {
+                public Something(IFeatureService featureService)
+                {
+                    Do(false);
+                }
+
+                private void Do(bool value) { }
+            }
+            """
+        );
+    }
+
+    [Fact]
     public async Task BracelessIfCheck_InlinesBody()
     {
         await RunDefaultCodeFixAsync(

--- a/extensions/Bitwarden.Server.Sdk.Features/tests/Bitwarden.Server.Sdk.Features.CodeFixers.Tests/RemoveFeatureFlagCodeFixerTests.cs
+++ b/extensions/Bitwarden.Server.Sdk.Features/tests/Bitwarden.Server.Sdk.Features.CodeFixers.Tests/RemoveFeatureFlagCodeFixerTests.cs
@@ -2329,7 +2329,7 @@ public class RemoveFeatureFlagCodeFixerTests : TestBase
     }
 
     [Fact]
-    public async Task NegatedFlagInAndChain_FalseShortCircuits_RemovesBlock()
+    public async Task NegatedFlagInAndChain_PreservesRemainingCondition()
     {
         await RunDefaultCodeFixAsync(
             """
@@ -2376,11 +2376,62 @@ public class RemoveFeatureFlagCodeFixerTests : TestBase
 
                 public void Process(IFeatureService featureService)
                 {
+                    if (_condition)
+                    {
+                        DoThing();
+                    }
 
                     Continue();
                 }
 
                 private void DoThing() { }
+                private void Continue() { }
+            }
+            """
+        );
+    }
+
+    [Fact]
+    public async Task NegatedFlagOnRightOfAndChain_PreservesNullGuard()
+    {
+        await RunDefaultCodeFixAsync(
+            """
+            using Bitwarden.Server.Sdk.Features;
+
+            namespace Test;
+
+            public class MyService
+            {
+                public void Process(IFeatureService featureService, object? data)
+                {
+                    if (data is not null && !featureService.IsEnabled(MyFlags.Flag))
+                    {
+                        throw new System.InvalidOperationException();
+                    }
+
+                    Continue();
+                }
+
+                private void Continue() { }
+            }
+            """,
+            """
+            using Bitwarden.Server.Sdk.Features;
+
+            namespace Test;
+
+            public class MyService
+            {
+                public void Process(IFeatureService featureService, object? data)
+                {
+                    if (data is not null)
+                    {
+                        throw new System.InvalidOperationException();
+                    }
+
+                    Continue();
+                }
+
                 private void Continue() { }
             }
             """


### PR DESCRIPTION
## 🎟️ Tracking

No ticket — internal code fixer improvements.

## 📔 Objective

Extends the `RemoveFeatureFlagCodeFixer` Roslyn code fixer with three improvements:

- **`is false` / `is true` patterns** — `if (featureService.IsEnabled(Flag) is false)` was previously left as unfolded `if (true is false)` after the invocation was replaced. Now handled directly in the switch arm (`is false` → keep else, drop then) and via a new `is`-pattern folding step in `SimplifyBooleanExpressions` for non-if contexts.
- **Spurious blank lines after mock removal** — switching from `RemoveNode(..., KeepTrailingTrivia)` to the existing `RemoveNodeCleanly` helper eliminates extra blank lines left when a multi-line `.Returns(...)` statement is removed.
- **Theory → Fact conversion** — when a `[Theory]` test with exactly `[InlineData(true)]` + `[InlineData(false)]` passes its bool param solely into `.Returns(param)`, the fixer now converts it to `[Fact]`, removes the `[InlineData]` attributes, removes the parameter, and deletes the `Returns` line.